### PR TITLE
曲検索機能およびユーザー検索機能の追加に必要なコントローラーの更新

### DIFF
--- a/app/Http/Controllers/SongsController.php
+++ b/app/Http/Controllers/SongsController.php
@@ -185,8 +185,8 @@ class SongsController extends Controller
         $favorite_artist = \Auth::user()->favorite_artist;
         
         $recommended_songs = Song::where("user_id","<>", \Auth::id())
-        ->where(function($query)use($favorite_music_age, $favorite_artist){
-            $query->where("music_age", $favorite_music_age)
+        ->where(function($query2)use($favorite_music_age, $favorite_artist){
+            $query2->where("music_age", $favorite_music_age)
             ->orWhere("artist_name", "like", "%".$favorite_artist. "%");
         })
         ->inRandomOrder()

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -10,11 +10,64 @@ use App\Song;
 
 class UsersController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {   
         $users = User::orderBy("id", "desc")->paginate(10);
         
         return view("users.index", ["users" => $users]);
+        
+        // 値を取得
+        $name = $request->input("name");
+        $age = $request->input("age");
+        $gender = $request->input("gender");
+        
+        // 検索QUERY
+        $query = User::query();
+        
+        // もし「名前」があれば
+        if(!empty($name))
+        {
+            $query->where("name", "like", "%".$name. "%");
+        }
+        
+        // もし「年齢」が選択されていれば
+        if(!empty($age))
+        {
+            $query->where("age", "like", "%".$age. "%");
+        }
+        
+        // もし「性別」が選択されていれば
+        if(!empty($gender))
+        {
+            $query->where("gender", $gender);
+        }
+        
+        // ページネーション
+        $users = $query->orderBy("created_at", "desc")->paginate(10);
+        
+        // 「好きな音楽の年代が一致」または「好きなアーティスト名が部分一致」
+        // であるユーザーをログインユーザーへのおすすめユーザーとする。
+        $favorite_music_age = \Auth::user()->favorite_music_age;
+        $favorite_artist = \Auth::user()->favorite_artist;
+        
+        $recommended_users = User::where("id","<>",\Auth::id())
+        ->where(function($query)use($favorite_music_age, $favorite_artist){
+            $query->where("favorite_music_age", $favorite_music_age)
+            ->orWhere("favorite_artist", "like", "%".$favorite_artist. "%");
+        })
+        ->inRandomOrder()
+        ->limit(12)
+        ->get();
+    
+        $data = [
+        "name" => $name,
+        "age" => $age,
+        "gender" => $gender,
+        "users" => $users,
+        "recommended_users" => $recommended_users,
+        ];
+        
+        return view("users.index", $data);
     }
     
     

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -51,8 +51,8 @@ class UsersController extends Controller
         $favorite_artist = \Auth::user()->favorite_artist;
         
         $recommended_users = User::where("id","<>",\Auth::id())
-        ->where(function($query)use($favorite_music_age, $favorite_artist){
-            $query->where("favorite_music_age", $favorite_music_age)
+        ->where(function($query2)use($favorite_music_age, $favorite_artist){
+            $query2->where("favorite_music_age", $favorite_music_age)
             ->orWhere("favorite_artist", "like", "%".$favorite_artist. "%");
         })
         ->inRandomOrder()


### PR DESCRIPTION
## 概要
- 曲検索機能およびユーザー検索機能を追加するために、SongsControllerとUsersControllerに記述を追加しました。
- SoncsControllerに関数searchを追加しました。曲名・アーティスト名・音楽の年代で絞り込み、「投稿が新しい順」・「お気に入りが多い順」・「コメントが多い順」のいずれかで並び替えができます。
　また、「曲の年代がユーザーの好きな音楽の年代と一致」または「アーティスト名がユーザーの好きなアーティスト名と部分一致」 である曲をユーザーへのおすすめ曲として検索結果の表示の下に表示させます。。
- UsersControllerに関数searchを追加しました。名前・年齢・性別で検索できます。
　また、「好きな音楽の年代が一致」または「好きなアーティスト名が部分一致」であるユーザーをログインユーザーへのおすすめとして、検索結果の表示の下に表示させます。

## 不安な点
- $queryを検索機能とおすすめ表示機能の2箇所で使っているのですが、同じ関数の中で複数箇所に使っても問題ないでしょうか？