### PR TITLE
曲へのコメント機能に必要なコントローラーおよびフォームリクエストの作成

### DIFF
--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\CreateCommentRequest;
+
+use App\Comment;
+
+class CommentsController extends Controller
+{
+    public function store(CreateCommentRequest $request)
+    {
+        Comment::create([
+            "user_id" => $request->user()->id,
+            "song_id" => $request->song_id,
+            "body" => $request->body,
+        ]);
+       
+        return back();
+    }
+    
+    
+    public function destroy($id)
+    {
+        $comment = Comment::find($id);
+        
+        if(\Auth::id() === $comment->user_id){
+            $comment->delete();
+        }
+        
+        return back();
+    }
+    
+}

--- a/app/Http/Controllers/SongsController.php
+++ b/app/Http/Controllers/SongsController.php
@@ -74,12 +74,14 @@ class SongsController extends Controller
      * @return \Illuminate\Http\Response
      */
     public function show(Song $song)
-    {
+    {   
+        $comments = $song->comments()->orderBy("created_at", "desc")->paginate(10);
         $user = \Auth::user();
         
         return view("songs.show",[
             "song" => $song,
             "user" => $user,
+            "comments" => $comments,
         ]);
     }
 

--- a/app/Http/Requests/CreateCommentRequest.php
+++ b/app/Http/Requests/CreateCommentRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateCommentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            "user_id" => "required",
+            "song_id" => "required",
+            "body" => "required|max:400",
+        ];
+    }
+    
+    public function attributes()
+    {
+        return [
+            "body" => "コメント本文",
+        ];
+    }
+}


### PR DESCRIPTION
**概要**

- ユーザーが自分および他人の投稿にコメントするのに必要な、コントローラー(CommentsController)およびフォームリクエスト(CreateCommentRequest)を作成しました。
- コメントの投稿・削除機能を作成しました。
- フォームリクエストを作成し、コメントは400字以内でないと投稿できないようにしています。
- 既存のSongsControllerの関数showに変数$commentsを追加しました。

**不安な点**
特にありません。

よろしくお願いします。