### PR TITLE
コメント投稿機能のルーティング・ビューの作成

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -175,6 +175,7 @@ h4.contributor-introduction-label{
     border-radius:10px;
     -webkit-border-radius:10px;
     -moz-border-radius:10px;
+    word-wrap: break-word;
 }
 
 .balloon-left:after,.balloon-left:before{
@@ -229,6 +230,14 @@ h4.contributor-introduction-label{
   margin: 0;
   padding: 0;
   font-size:15px;
+}
+
+.comment-side{
+  width: 200px;
+}
+
+.comment-user-name{
+  font-size: 15px;
 }
 
  /*　画面サイズが480pxから768pxのとき　*/

--- a/resources/views/songs/search.blade.php
+++ b/resources/views/songs/search.blade.php
@@ -215,6 +215,8 @@
                         
                         <div class="d-flex ml-4 my-2">
                             @include("favorite.favorite_button", ["song" => $song])
+                            
+                            <a href="{{ route("songs.show", ["song" => $song]) }}" class="btn btn-light d-block p-1 ml-2"><i class="far fa-comments mr-2"></i>コメント {{ count($song->comments) }} 件</a>
                         </div>
                         
                         <div class="contributor-button ml-4 pr-2">

--- a/resources/views/songs/show.blade.php
+++ b/resources/views/songs/show.blade.php
@@ -142,4 +142,81 @@
         </div>
         
     </section>
+    
+    <section class="comment">
+        <div class="comments-index mb-5">
+            
+            @if(count($song->comments) > 0)
+            <p class="comments-counts"><i class="far fa-comments mr-2"></i>コメント（{{ count($song->comments) }}）</p>
+            @else
+            <p>コメントはまだありません。</p>
+            @endif
+            
+            <div class="comment-display">
+                <ul class="list-unstyled">
+                @foreach($comments as $comment)
+                    <li class ="py-2 border-top">
+                        <div class="d-flex">
+                                <figure class="ml-3 mr-4 my-auto">
+                                    @if($comment->user->image_url)
+                                    <img src="{{ $comment->user->image_url }}" alt="画像" class="circle2"> 
+                                    @elseif($comment->user->gender == 1)
+                                    <img src="https://s3-ap-northeast-1.amazonaws.com/original-yoursongs/man.jpeg" alt="画像" class="circle2">
+                                    @elseif($comment->user->gender == 2)
+                                    <img src="https://s3-ap-northeast-1.amazonaws.com/original-yoursongs/woman.jpeg" alt="画像" class="circle2">
+                                    @else
+                                    <img src="https://original-yoursongs.s3-ap-northeast-1.amazonaws.com/qustion-mark.jpeg" alt="画像" class="circle2">
+                                    @endif 
+                                    <figcaption class="text-center m-0">
+                                        <a class="comment-user-name" href="{{ route("users.show", ["id" => $comment->user->id]) }}">{{ $comment->user->name }}</a>
+                                    </figcaption>
+                                </figure>
+                                
+                                <div class="balloon-left ml-3 my-auto">
+                                    <p>{{ $comment->body }}</p>
+                                </div>
+                        </div>    
+                        
+                        <div class="comment-side ml-auto mb-1">
+                            <ul class="list-unstyled">
+                                <li class="mr-3">
+                                    <span class="post-time text-muted">  投稿  {{ $comment->created_at }}</span>
+                                </li>
+                                <li class="mr-3">
+                                    @if(Auth::id() === $comment->user_id)
+                                    {!! Form::open(["route" => ["comments.destroy", $comment->id], "method" => "delete"]) !!}
+                                        {!! Form::submit("削除", ["class" => "btn btn-danger btn-sm"]) !!}
+                                    {!! Form::close() !!}
+                                    @endif
+                                </li>
+                            </ul>
+                        </div>
+                    </li>
+                @endforeach
+                </ul>
+            </div>
+            
+            {{ $comments->render("pagination::bootstrap-4") }}
+        </div>
+    
+        <div class="comment-post-form">        
+            <h4 class="mb-3 text-center"><i class="far fa-comment mr-2"></i>コメントを投稿する</h2>
+            
+            <div class="comment-form">   
+                    {!! Form::open(["route" => ["comments.store", $song->id]]) !!}
+                        {!! Form::hidden("song_id", $song->id) !!}
+                        {!! Form::hidden("user_id", $user->id) !!}
+                        
+                        
+                        <div class="row m-0">
+                            {!! Form::textarea("body", old("body"), ["class" => "form-control col-sm-8 offset-sm-2", "rows" => "4"]) !!}
+                        </div>
+                        
+                        <div class="text-center m-3">
+                            {!! Form::submit("投稿する", ["class" => "btn btn-primary"]) !!}
+                        </div>   
+                    {!! Form::close() !!}
+            </div>
+        </div>
+    </section>
 @endsection

--- a/resources/views/songs/songs.blade.php
+++ b/resources/views/songs/songs.blade.php
@@ -130,6 +130,8 @@
             
             <div class="d-flex ml-4 my-2">
                 @include("favorite.favorite_button", ["song" => $song])
+                
+                <a href="{{ route("songs.show", ["song" => $song]) }}" class="btn btn-light d-block p-1 ml-2"><i class="far fa-comments mr-2"></i>コメント（{{ count($song->comments) }}）</a>
             </div>
             
             <div class="contributor-button ml-4 pr-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,7 +40,8 @@ Route::group(["middleware" => "auth"], function(){
     // 曲の一覧表示・登録画面表示・登録処理・取得表示・更新画面表示・更新処理・削除処理
     Route::resource("songs", "SongsController");
     
-    
+    // 曲へのコメントの投稿・削除
+    Route::resource("comments", "CommentsController", ["only" =>["store", "destroy"]]);
     
     Route::group(["prefix" => "users/{id}"], function(){
         Route::post("follow", "UserFollowController@store")->name("user.follow");


### PR DESCRIPTION
**概要**
- 自分もしくは他人の投稿した曲へのコメント投稿に必要なルーティング・ビューの作成を行いました。

- コメントの投稿・削除に必要なルーティングを追加しました。
-  曲詳細画面にコメント投稿フォーム・コメント一覧を追加しました。
-  曲カードに曲へのコメント数の表示を追加しました。

**不安な点**

- 特にありません。

よろしくお願いいたします。