### PR TITLE
管理者権限機能に必要なカラム・ゲート定義・論理削除（ソフトデリート）の追加

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -25,6 +25,19 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        //
+        // 開発者のみ許可
+        Gate::define("system-only", function($user){
+            return($user->role === 1);
+        });
+        
+        // 管理者以上(管理者＆システム管理者)に許可
+        Gate::define("admin-higher", function($user){
+            return($user->role > 0 && $user->role <= 5);
+        });
+        
+        // 全権限に許可
+        Gate::define("user-higher", function($user){
+            return($user->role > 0 && $user->role <= 10);
+        });
     }
 }

--- a/app/Song.php
+++ b/app/Song.php
@@ -3,9 +3,12 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Song extends Model
-{
+{   
+    use SoftDeletes;
+    
     protected $fillable = ["user_id", "title", "artist_name",  "music_age", "description", "image_url", "video_url",];
     
     public function user()

--- a/database/migrations/2019_08_15_082612_add_column_role_to_users_table.php
+++ b/database/migrations/2019_08_15_082612_add_column_role_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddColumnRoleToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table("users", function (Blueprint $table) {
+            $table->tinyInteger("role")->default(10)->after("password")->index("index_role")->comment("ロール");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table("users", function (Blueprint $table) {
+            $table->dropColumn("role");
+        });
+    }
+}

--- a/database/migrations/2019_08_18_042558_add_column_soft_deletes_to_songs_table.php
+++ b/database/migrations/2019_08_18_042558_add_column_soft_deletes_to_songs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddColumnSoftDeletesToSongsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table("songs", function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table("songs", function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
**概要**
- 管理者権限機能に必要なカラム・ゲート定義・論理削除（ソフトデリート）の追加を行いました。

- usersテーブルにカラム「role」を追加し、ゲート定義を実行しました。
1.開発者のみの権限
2.管理者以上（管理者および開発者）の権限
3.全てのユーザーの権限
を定義しています。

- 論理削除（ソフトデリート）を実装しました。

**その他**
- 管理者権限機能は、
1. 「曲の削除」
2.「削除した曲を復活させる」
3.「削除済みの曲を完全に削除する」
の３つを想定しています。

**不安な点**
ゲート定義にて、今のところ使うか分からない「開発者のみの権限」も念のため定義していますが、使うとはっきり分かるまでは定義しない方が良かったでしょうか？

よろしくお願い致します。