### PR TITLE
開発者権限についてコメント／Song.phpの$fillableに「deleted_at」を追加（#17の修正分）

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -25,7 +25,7 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        // 開発者のみ許可
+        // 開発者のみ許可。使用予定はなく、アプリ完成後削除する予定。
         Gate::define("system-only", function($user){
             return($user->role === 1);
         });

--- a/app/Song.php
+++ b/app/Song.php
@@ -9,7 +9,7 @@ class Song extends Model
 {   
     use SoftDeletes;
     
-    protected $fillable = ["user_id", "title", "artist_name",  "music_age", "description", "image_url", "video_url",];
+    protected $fillable = ["user_id", "title", "artist_name", "music_age", "description", "image_url", "video_url", "deleted_at"];
     
     public function user()
     {


### PR DESCRIPTION
**概要**
- 管理者権限を実装したプルリクエスト（#17）の修正分です。
- プルリクエスト（#17）を保留した状態でプルリクエスト（#18）を作成し確認後マージしたため（レビュワーのmanaberuitさまの同意済み）、プルリクエスト（#17）もクローズドされたため、新たにプルリクエストを作成しました。

**修正点**
- app/Providers/AuthServiceProvider.phpの開発者権限について、今後使用する可能性が低いため、アプリ完成後削除することをコメントしました。
- app/Song.phpの$fillableに「deleted_at」を追加しました。

よろしくお願いいたします。