### PR TITLE
管理者権限機能に必要なルーティング・曲管理画面の作成／管理者としての曲削除ボタン・曲管理画面へのリンクの追加

### DIFF
--- a/resources/views/commons/navbar.blade.php
+++ b/resources/views/commons/navbar.blade.php
@@ -15,6 +15,12 @@
             <ul class="navbar-nav">
                 <!--ログイン中のナビゲーションバー-->
                 @if (Auth::check())
+                    @if(Auth::user()->role === 5)
+                    <li class="nav-item">
+                        <a href="{{ url("/index-for-admin") }}" class="nav-link"><i class="fas fa-trash-alt mr-1"></i>曲の管理画面</a>
+                    </li>
+                    @endif
+                    
                     <li class="nav-item"><a href="{{ url("songs") }}" class="nav-link"><i class="far fa-clock mr-1"></i>タイムライン</a></li>
                     <li class="nav-item"><a href="{{ url("search/songs") }}" class="nav-link"><i class="fas fa-music mr-1"></i>曲を検索</a></li>
                     <li class="nav-item"><a href="{{ url("search/users") }}" class="nav-link"><i class="fas fa-user mr-1"></i>ユーザーを検索</a></li>

--- a/resources/views/songs/index_for_admin.blade.php
+++ b/resources/views/songs/index_for_admin.blade.php
@@ -9,7 +9,7 @@
 <div class="users-index mb-3">
     <h4 class="text-center">未削除</h4>
     <table border="1" class="m-auto text-center">
-        <tbody>
+        <thead>
             <tr>
                 <th>曲ID</th>
                 <th>曲名</th>
@@ -20,30 +20,33 @@
                 <th>曲の詳細</th>
                 <th>削除</th>
             </tr>
-            @forelse ($songs as $song)
-                <tr>
-                    <td>{{ $song->id }}</td>
-                    <td>{{ $song->title }}</td>
-                    <td>{{ $song->artist_name }}</td>
-                    <td>{{ $song->music_age }}</td>
-                    <td>{{ $song->user_id }}</td>
-                    <td><a href="{{ route("users.show", ["id" => $song->user->id]) }}">{{ $song->user->name }}</a></td>
-                    <td>
-                         <a class="btn btn-success btn-sm" href="{{ route("songs.show", ["id" => $song->id]) }}">曲の詳細</a>
-                    </td>
-                    <td>
-                        <a href="/delete/{{ $song->id }}" onclick="delete_alert();return false;">削除</a>
-                    </td>
-                </tr>
-            @empty
-                <tr>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                </tr>
-            @endforelse
+        </thead>
+        
+        <tbody>
+        @forelse ($songs as $song)
+            <tr>
+                <td>{{ $song->id }}</td>
+                <td>{{ $song->title }}</td>
+                <td>{{ $song->artist_name }}</td>
+                <td>{{ $song->music_age }}</td>
+                <td>{{ $song->user_id }}</td>
+                <td><a href="{{ route("users.show", ["id" => $song->user->id]) }}">{{ $song->user->name }}</a></td>
+                <td>
+                     <a class="btn btn-success btn-sm" href="{{ route("songs.show", ["id" => $song->id]) }}">曲の詳細</a>
+                </td>
+                <td>
+                    <a href="/delete/{{ $song->id }}" onclick="delete_alert();return false;">削除</a>
+                </td>
+            </tr>
+        @empty
+            <tr>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+            </tr>
+        @endforelse
         </tbody>
     </table>
 </div>
@@ -51,7 +54,7 @@
 <div class="deleted-users-index">
     <h4 class="text-center">削除済</h4>
     <table border="1" class="m-auto text-center">
-        <tbody>
+        <thead>
             <tr>
                 <th>曲ID</th>
                 <th>曲名</th>
@@ -62,33 +65,36 @@
                 <th>復旧</th>
                 <th>完全削除</th>
             </tr>
-            @forelse ($deleted as $delete)
-                <tr>
-                    <td>{{ $delete->id }}</td>
-                    <td>{{ $delete->title }}</td>
-                    <td>{{ $delete->artist_name }}</td>
-                    <td>{{ $delete->music_age }}</td>
-                    <td>{{ $delete->user_id }}</td>
-                    <td><a href="{{ route("users.show", ["id" => $delete->user->id]) }}">{{ $delete->user->name }}</a></td>
-                    <td>
-                        <a href="/restore/{{ $delete->id }}">復旧</a>
-                    </td>
-                    <td>
-                        <a href="/force-delete/{{ $delete->id }}">完全削除</a>
-                    </td>
-                </tr>
-            @empty
-                <tr>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                    <td>-</td>
-                </tr>
-            @endforelse
+        </thead>
+        
+        <tbody>
+        @forelse ($deleted as $delete)
+            <tr>
+                <td>{{ $delete->id }}</td>
+                <td>{{ $delete->title }}</td>
+                <td>{{ $delete->artist_name }}</td>
+                <td>{{ $delete->music_age }}</td>
+                <td>{{ $delete->user_id }}</td>
+                <td><a href="{{ route("users.show", ["id" => $delete->user->id]) }}">{{ $delete->user->name }}</a></td>
+                <td>
+                    <a href="/restore/{{ $delete->id }}">復旧</a>
+                </td>
+                <td>
+                    <a href="/force-delete/{{ $delete->id }}">完全削除</a>
+                </td>
+            </tr>
+        @empty
+            <tr>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+            </tr>
+        @endforelse
         </tbody>
     </table>
 </div>

--- a/resources/views/songs/index_for_admin.blade.php
+++ b/resources/views/songs/index_for_admin.blade.php
@@ -1,0 +1,96 @@
+@extends("layouts.app")
+
+@section("content")
+<h1 class="mb-4 text-center page-title">
+    <i class="fas fa-trash-alt mr-1"></i>
+    曲の管理画面
+</h1>
+
+<div class="users-index mb-3">
+    <h4 class="text-center">未削除</h4>
+    <table border="1" class="m-auto text-center">
+        <tbody>
+            <tr>
+                <th>曲ID</th>
+                <th>曲名</th>
+                <th>アーティスト</th>
+                <th>曲の年代</th>
+                <th>投稿者ＩＤ</th>
+                <th>投稿者</th>
+                <th>曲の詳細</th>
+                <th>削除</th>
+            </tr>
+            @forelse ($songs as $song)
+                <tr>
+                    <td>{{ $song->id }}</td>
+                    <td>{{ $song->title }}</td>
+                    <td>{{ $song->artist_name }}</td>
+                    <td>{{ $song->music_age }}</td>
+                    <td>{{ $song->user_id }}</td>
+                    <td><a href="{{ route("users.show", ["id" => $song->user->id]) }}">{{ $song->user->name }}</a></td>
+                    <td>
+                         <a class="btn btn-success btn-sm" href="{{ route("songs.show", ["id" => $song->id]) }}">曲の詳細</a>
+                    </td>
+                    <td>
+                        <a href="/delete/{{ $song->id }}" onclick="delete_alert();return false;">削除</a>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+    
+<div class="deleted-users-index">
+    <h4 class="text-center">削除済</h4>
+    <table border="1" class="m-auto text-center">
+        <tbody>
+            <tr>
+                <th>曲ID</th>
+                <th>曲名</th>
+                <th>アーティスト</th>
+                <th>曲の年代</th>
+                <th>投稿者ＩＤ</th>
+                <th>投稿者</th>
+                <th>復旧</th>
+                <th>完全削除</th>
+            </tr>
+            @forelse ($deleted as $delete)
+                <tr>
+                    <td>{{ $delete->id }}</td>
+                    <td>{{ $delete->title }}</td>
+                    <td>{{ $delete->artist_name }}</td>
+                    <td>{{ $delete->music_age }}</td>
+                    <td>{{ $delete->user_id }}</td>
+                    <td><a href="{{ route("users.show", ["id" => $delete->user->id]) }}">{{ $delete->user->name }}</a></td>
+                    <td>
+                        <a href="/restore/{{ $delete->id }}">復旧</a>
+                    </td>
+                    <td>
+                        <a href="/force-delete/{{ $delete->id }}">完全削除</a>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>-</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+
+@endsection

--- a/resources/views/songs/search.blade.php
+++ b/resources/views/songs/search.blade.php
@@ -230,7 +230,11 @@
                         </div>
                         
                         <!--管理者としてログインしている場合に限り曲を削除できる-->
-                        <!--管理者権限を追加してから作成する-->
+                        @if(Auth::user()->role === 5 && Auth::id() !== $song->user->id)
+                        <div class="delete-song-button mb-3 text-center">
+                            <a class="btn btn-danger" href="/delete/{{ $song->id }}">管理者権限でこの曲を削除</a>
+                        </div>
+                        @endif
                     </li>
                 @endforeach
                 </ul>

--- a/resources/views/songs/show.blade.php
+++ b/resources/views/songs/show.blade.php
@@ -141,6 +141,13 @@
                 @endif
         </div>
         
+        <!--管理者としてログインしている場合に限りアカウントを削除できる-->
+        @if(Auth::user()->role === 5 && Auth::id() !== $song->user->id)
+        <div class="delete-song-button mb-3 text-center">
+            <a class="btn btn-danger" href="/delete/{{ $song->id }}">管理者権限でこの曲を削除</a>
+        </div>
+        @endif
+        
     </section>
     
     <section class="comment">

--- a/resources/views/songs/songs.blade.php
+++ b/resources/views/songs/songs.blade.php
@@ -143,6 +143,13 @@
                     {!! Form::close() !!}
                 @endif
             </div>
+            
+            <!--管理者としてログインしている場合に限り曲を削除できる-->
+            @if(Auth::user()->role === 5 && Auth::id() !== $song->user->id)
+            <div class="delete-song-button mb-3 text-center">
+                <a class="btn btn-danger" href="/delete/{{ $song->id }}">管理者権限でこの曲を削除</a>
+            </div>
+            @endif
         </li>
     @endforeach
 </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,8 +26,8 @@ Route::group(["middleware" => "guest"], function(){
    
 });
 
-// ログイン時
-Route::group(["middleware" => "auth"], function(){
+// ログインしている全ユーザー
+Route::group(["middleware" => ["auth", "can:user-higher"]], function(){
     // ログイン時のトップページ
     Route::get("/home", "SongsController@index")->name("home");
     
@@ -66,4 +66,12 @@ Route::group(["middleware" => "auth"], function(){
         // 曲の検索機能
         Route::get("songs", "SongsController@search")->name("songs.search");
     });
+});
+
+// 管理者権限機能
+Route::group(["middleware" => ["auth", "can:admin-higher"]], function(){
+        Route::get("index-for-admin", "SongsController@indexForAdmin")->name("songs.indexForAdmin");
+        Route::get("delete/{id}", "SongsController@delete")->name("songs.delete");
+        Route::get("restore/{id}", "SongsController@restore")->name("songs.restore");
+        Route::get("force-delete/{id}", "SongsController@forceDelete")->name("songs.forceDelete");
 });


### PR DESCRIPTION
**概要**
- 管理者権限機能に必要なルーティングを追加しました。
「 曲管理画面を開く機能」・「曲の削除機能」・「削除済みの曲を復活させる機能」・「削除済みの曲を完全に削除する機能」を追加しています。
- 曲管理画面を作成しました。
　投稿されている曲一覧・削除済みの曲一覧を表示し、それぞれ削除・完全削除ができるようになっています。
- 管理者としてログイン時の曲カード・曲検索画面・曲詳細画面に、「管理者としての曲削除ボタン」を追加しました。
- 管理者としてログイン時のナビゲーションバーに、曲管理画面へのリンクを追加しました。

**不安な点**
特にありません。

よろしくお願いします。