### PR TITLE
GithubでのOAuth認証に必要なルーティングおよびログインボタンの作成

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -255,6 +255,16 @@ h4.contributor-introduction-label{
   font-size: 15px;
 }
 
+.btn-github{
+  background-color: #555555;
+  color : white;
+}
+
+.btn-github:hover{
+  background-color: #999999;
+  color : white;
+}
+
  /*　画面サイズが480pxから768pxのとき　*/
 @media screen and (min-width:480px) { 
 .song-video{

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -22,6 +22,8 @@
                 {!! Form::submit("ログイン", ["class" => "btn btn-primary btn-block"]) !!}
             {!! Form::close() !!}
             
+            <a href="/login/github" class="btn-github btn btn-default btn-block mt-4"><i class="fab fa-github mr-1"></i>Githubアカウントでログイン</a>
+            
             <p class="mt-2">未登録の方は <a href="{{ route("signup.get") }}">こちら</a>から新規登録できます。</p>
         </div>
     </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -13,6 +13,8 @@
                 
                {!! Form::submit("上記の内容で登録", ["class" => "btn btn-primary btn-block"]) !!}
             {!! Form::close() !!}
+            
+            <a href="/login/github" class="btn-github btn btn-default btn-block mt-4"><i class="fab fa-github mr-1"></i>Githubアカウントで登録</a>
         </div>
     </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,10 @@ Route::group(["middleware" => "guest"], function(){
     // ログイン認証
     Route::get("login", "Auth\LoginController@showLoginForm")->name("login");
     Route::post("login", "Auth\LoginController@login")->name("login.post");
+    
+    // SNS認証
+    Route::get("login/{provider}", "Auth\SocialAccountController@redirectToProvider")->name("socialOAuth");
+    Route::get("login/{provider}/callback", "Auth\SocialAccountController@handleProviderCallback")->name("oauthCallback");
    
 });
 


### PR DESCRIPTION
**概要**
- GithubでのOAuth認証に必要なルーティングを作成し、ログインボタンをログイン画面・ユーザー登録画面に追加しました。
- ルーティングに関して、任意のプロバイダーで使えるようにルートパラメーターproviderを使っています。
- Client ID、Secret key、コールバックURLを.envファイルに記述しています。

**不安な点**
- 特にありません。

よろしくおねがいいたします。