### PR TITLE
PHPUnitを用いてのテストに必要な設定およびユーザー認証テストの作成

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -25,7 +25,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = "/";
+    protected $redirectTo = "/home";
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -27,7 +27,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = "/";
+    protected $redirectTo = "/home";
 
     /**
      * Create a new controller instance.

--- a/config/database.php
+++ b/config/database.php
@@ -77,6 +77,21 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
         ],
+        
+        'test.mysql' => [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => env('DB_DATABASE', 'forge'),
+            'username' => env('DB_USERNAME', 'forge'),
+            'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'strict' => true,
+            'engine' => null,
+        ],
 
     ],
 
@@ -114,6 +129,8 @@ return [
             'port' => env('REDIS_PORT', 6379),
             'database' => 0,
         ],
+        
+    
 
     ],
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -14,10 +14,15 @@ use Faker\Generator as Faker;
 */
 
 $factory->define(App\User::class, function (Faker $faker) {
+    static $password;
+    
     return [
-        'name' => $faker->name,
-        'email' => $faker->unique()->safeEmail,
-        'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
-        'remember_token' => str_random(10),
+        "name" => $faker->name,
+        "email" => $faker->unique()->safeEmail,
+        "password" => $password ?: $password = bcrypt("test1234"),
+        "remember_token" => str_random(10),
+        "age" => $faker->randomElement([10, 20, 30, 40, 50, 60, 70]),
+        "gender" => $faker->randomElement([1, 2]),
+        "role" => 10,
     ];
 });

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,5 +27,6 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="DB_DATABASE" value="test.mysql"/>
     </php>
 </phpunit>

--- a/resources/views/commons/error_messages.blade.php
+++ b/resources/views/commons/error_messages.blade.php
@@ -1,4 +1,4 @@
-@if (count($errors) > 0)
+@if (isset($errors) && count($errors) > 0)
     <ul class="alert alert-danger" role="alert">
         @foreach ($errors->all() as $error)
             <li class="ml-4">{{ $error }}</li>

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+use App\User;
+
+use Auth;
+
+class LoginTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+     
+    use RefreshDatabase;
+    use WithoutMiddleware;
+    
+    public function test_user_can_see_login_page()
+    {   
+        $response = $this->get(route("login"));
+
+        $response->assertStatus(200);
+    }
+    
+    public function test_valid_user_can_login()
+    {   
+        // ユーザーを１つ作成
+        $user = factory(User::class)->create([
+            "password" => bcrypt("test1111")
+        ]);
+        
+        // まだ認証されていない
+        $this->assertFalse(Auth::check());
+        
+        // ログイン実行
+        $response = $this->post(route("login.post"), [
+            "email" => $user->email,
+            "password" => "test1111"
+        ]);
+        
+        // 認証されている
+        $this->assertTrue(Auth::check());
+        
+        // ログイン後にトップページにリダイレクトされる
+        $response->assertStatus(302);
+        $response->assertRedirect(route("home"));
+    }
+    
+    public function test_invalid_user_cannot_login()
+    {   
+        // ユーザーを１つ作成
+        $user = factory(User::class)->create([
+            "password" => bcrypt("test1111")
+        ]);
+        
+        // まだ認証されていない
+        $this->assertFalse(Auth::check());
+        
+        // 異なるパスワードでログイン実行
+        $response = $this->from(route("login"))->post(route("login.post"), [
+            "email" => $user->email,
+            "password" => "test2222"
+        ]);
+        
+        // 認証失敗
+        $this->assertFalse(Auth::check());
+        
+        // ログイン画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route("login"));
+    }
+}

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -30,6 +30,8 @@ class LoginTest extends TestCase
     
     public function test_valid_user_can_login()
     {   
+        $this->withoutExceptionHandling();
+        
         // ユーザーを１つ作成
         $user = factory(User::class)->create([
             "password" => bcrypt("test1111")
@@ -38,8 +40,10 @@ class LoginTest extends TestCase
         // まだ認証されていない
         $this->assertFalse(Auth::check());
         
+        // dd($user->password);
+        
         // ログイン実行
-        $response = $this->post(route("login.post"), [
+        $response = $this->from(route("login"))->post(route("login.post"), [
             "email" => $user->email,
             "password" => "test1111"
         ]);

--- a/tests/Feature/LogoutTest.php
+++ b/tests/Feature/LogoutTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\User;
+
+use Auth;
+
+class LogoutTest extends TestCase
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+     
+    use RefreshDatabase;
+     
+    public function test_logout()
+    {  
+        // ユーザーを１つ作成
+        $user = factory(User::class)->create();
+        
+        // ログイン済み
+        $this->actingAs($user);
+        
+        // 認証済み
+        $this->assertTrue(Auth::check());
+        
+        // ログアウトを実行
+        $response = $this->get(route("logout.get"));
+        
+        // 認証されていない
+        $this->assertFalse(Auth::check());
+        
+        // トップページにリダイレクト
+        $response->assertRedirect(route("welcome"));
+    }
+}

--- a/tests/Feature/OAuthTest.php
+++ b/tests/Feature/OAuthTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class OAuthTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+     
+     use RefreshDatabase;
+     
+    public function test_user_can_see_OAuth_page()
+    {
+        $this->providerName = "github";
+        $this->get(route("socialOAuth", ["provider" => $this->providerName]))
+            ->assertStatus(302);
+    }
+    
+    public function test_user_can_signup_width_github_account()
+    {
+        $this->providerName = "github";
+         
+        // URLをコール
+        $this->get(route("oauthCallback", ["provider" => $this->providerName]))
+            ->assertStatus(302);
+    }
+}

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -33,8 +33,10 @@ class RegisterTest extends TestCase
     
     public function test_request_should_pass_when_data_is_provided()
     {   
+        $this->withoutExceptionHandling();
+        
         // ユーザー登録
-        $response = $this->post(route("signup.post"),[
+        $response = $this->from(route("welcome"))->post(route("signup.post"),[
             "name" => "aaa",
             "email" => "bbb@gmail.com",
             "password" => "cccccc",

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+use Hash;
+
+use App\User;
+
+use Auth;
+
+class RegisterTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+     
+    use RefreshDatabase;
+    use WithoutMiddleware;
+    
+    public function test_user_can_see_signup_page()
+    {   
+        //ユーザー登録画面を表示する
+        $response = $this->get(route("signup.get"));
+        $response->assertStatus(200);
+    }
+    
+    public function test_request_should_pass_when_data_is_provided()
+    {   
+        // ユーザー登録
+        $response = $this->post(route("signup.post"),[
+            "name" => "aaa",
+            "email" => "bbb@gmail.com",
+            "password" => "cccccc",
+            "password_confirmation" => "cccccc"
+        ]);
+        
+        // // ユーザー登録成功後、トップページにページ移動
+        $response->assertStatus(302);
+        $response->assertRedirect(route("home"));
+        
+        // データベースのusersテーブルに追加されていることを確認
+        $this->assertDatabaseHas("users", [
+            "name" => "aaa",
+            "email" => "bbb@gmail.com",
+        ]);
+        
+        $user = User::where("email", "bbb@gmail.com")->first();
+        $this->assertTrue(Hash::check("cccccc", $user->password));
+    }
+    
+    public function test_request_should_fail_when_no_name_is_provided()
+    {   
+        // ユーザー名を空白の状態でユーザー登録を試みる
+        $response = $this->from(route("signup.get"))->post(route("signup.post"),[
+            "name" => "",
+            "email" => "bbb@gmail.com",
+            "password" => "cccccc",
+            "password_confirmation" => "cccccc",
+        ]);
+        
+        // ユーザー登録に失敗し、同画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route("signup.get"));
+        
+        // データベースのusersテーブルに追加されていないことを確認
+        $this->assertDatabaseMissing("users", [
+            "name" => "",
+            "email" => "bbb@gmail.com",
+        ]);
+    }
+    
+    public function test_request_should_fail_when_no_email_is_provided()
+    {   
+       // メールアドレスを空白の状態でユーザー登録を試みる
+        $response = $this->from(route("signup.get"))->post(route("signup.post"),[
+            "name" => "aaa",
+            "email" => "",
+            "password" => "cccccc",
+            "password_confirmation" => "cccccc"
+        ]);
+        
+        // ユーザー登録に失敗し、同画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route("signup.get"));
+        
+        // データベースのusersテーブルに追加されていないことを確認
+        $this->assertDatabaseMissing("users", [
+            "name" => "aaa",
+            "email" => "",
+        ]);
+    }
+    
+    public function test_request_should_fail_when_no_password_is_provided()
+    {   
+        // パスワードを空白のままユーザー登録を試みる
+        $response = $this->from(route("signup.get"))->post(route("signup.post"),[
+            "name" => "aaa",
+            "email" => "bbb@gmail.com",
+            "password" => "",
+            "password_confirmation" => "",
+        ]);
+        
+        // ユーザー登録に失敗し、同画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route("signup.get"));
+        
+        // データベースのusersテーブルに追加されていないことを確認
+        $this->assertDatabaseMissing("users", [
+            "name" => "aaa",
+            "email" => "bbb@gmail.com",
+        ]);
+    }
+    
+    public function test_request_should_fail_when_password_doesnot_match_password_confirmation()
+    {   
+        // パスワード記入欄の値とパスワード確認欄の値が異なるままユーザー登録を試みる
+        $response = $this->from(route("signup.get"))->post(route("signup.post"),[
+            "name" => "aaa",
+            "email" => "bbb@gmail.com",
+            "password" => "cccccc",
+            "password_confirmation" => "dddddd"
+        ]);
+        
+        // ユーザー登録に失敗し、同画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route("signup.get"));
+        
+        // データベースのusersテーブルに追加されていないことを確認
+        $this->assertDatabaseMissing("users", [
+            "name" => "aaa",
+            "email" => "bbb@gmail.com",
+            "password" => bcrypt("cccccc"),
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,10 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+    
+    public function from(string $url)
+    {
+        session()->setPreviousUrl(url($url));
+        return $this;
+    }
 }


### PR DESCRIPTION
**概要**
- PHPUnitでのテスト実行に必要な記述をphpunit.xml・TestCase.phpに追加しました。
- ファクトリUserFactoryを作成しました。
- テスト実行時にエラーの要因となっていた、エラーメッセージについて記述を修正しました。
- テストファイルを４つ作成しました。
RegisterTest→テスト１つ失敗（test_request_should_pass_when_data_is_provided）
LoginTest→テスト１つ失敗（test_valid_user_can_login）
LogoutTest→テスト全て成功
OAuthTest→テスト全て成功


**不明点**
- RegisterTestおよびLoginTestにおいてエラーが発生する箇所がありますので、見ていただきたいです。（#26）