### PR TITLE
曲の新規作成および更新時のタイトル・アーティスト名・説明の文字数変更

### DIFF
--- a/app/Http/Requests/CreateSongRequest.php
+++ b/app/Http/Requests/CreateSongRequest.php
@@ -24,10 +24,10 @@ class CreateSongRequest extends FormRequest
     public function rules()
     {
         return [
-            "title" => "required|max:15",
-            "artist_name" => "required|max:15",
+            "title" => "required|max:30",
+            "artist_name" => "required|max:30",
             "music_age" => "required|integer",
-            "description" => "nullable|max:200",
+            "description" => "nullable|max:300",
             "video_url" => "nullable|string|max:200",
         ];
     }

--- a/app/Http/Requests/UpdateSongRequest.php
+++ b/app/Http/Requests/UpdateSongRequest.php
@@ -25,10 +25,10 @@ class UpdateSongRequest extends FormRequest
     public function rules()
     {
         return [
-            "title" => "required|max:15",
-            "artist_name" => "required|max:15",
+            "title" => "required|max:30",
+            "artist_name" => "required|max:30",
             "music_age" => "required|integer",
-            "description" => "nullable|max:200",
+            "description" => "nullable|max:300",
             "video_url" => "nullable|string|max:200",
         ];
     }


### PR DESCRIPTION
**概要**
- 曲の新規作成および更新時のタイトル・アーティスト名・説明の文字数を変更しました。

**CreateSongRequestおよびUpdateSongRequestの変更点**
- titleを「max:15」から「max:30」へ
- artist_nameを「max:15」から「max:30」へ
- descriptionを「max:200」から「max:300」へ


**その他**
メンターご多忙のため、コードレビューはなし。


