### PR TITLE
ファクトリSongFactoryの作成および曲投稿機能・お気に入り機能のテストの作成

### DIFF
--- a/database/factories/SongFactory.php
+++ b/database/factories/SongFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(App\Song::class, function (Faker $faker) {
+    return [
+        "user_id" => function(){
+            return factory(App\User::class)->create()->id;  
+        },
+        "title" => $faker->name,
+        "artist_name" => $faker->name,
+        "music_age" => $faker->randomElement([1970, 1980, 1990, 2000, 2010]),
+    ];
+});
+

--- a/tests/Feature/FavoriteTest.php
+++ b/tests/Feature/FavoriteTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+use App\User;
+use App\Song;
+
+class FavoriteTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    
+    use RefreshDatabase;
+    use WithoutMiddleware;
+    
+    public function test_user_can_add_song_to_favorites()
+    {
+        // ユーザーを1人作成
+        $user = factory(User::class)->create();
+        
+        //曲を1つ作成
+        $song = factory(Song::class)->create();
+        
+        //曲をお気に入り登録する
+        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("favorites.favorite", ["id" => $song->id]));
+        
+        // 同じ画面にリダイレクト
+        $response->assertStatus(302);
+        $response->assertRedirect(route("songs.show", ["id" => $song->id]));
+        
+        // データベースにお気に入りとして保存されていることを確認
+        $this->assertDatabaseHas("favorites", [
+            "user_id" => $user->id,
+            "song_id" => $song->id,
+        ]);
+    }
+    
+    public function test_user_can_remove_song_from_favorites()
+    {
+        // ユーザーを1人作成
+        $user = factory(User::class)->create();
+        
+        //曲を1つ作成
+        $song = factory(Song::class)->create();
+        
+        //曲をお気に入り登録する
+        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("favorites.favorite", ["id" => $song->id]));
+        
+        //曲をお気に入りから外す
+        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->delete(route("favorites.unfavorite", ["id" => $song->id]));
+        
+        // 同じ画面にリダイレクト
+        $response->assertStatus(302);
+        $response->assertRedirect(route("songs.show", ["id" => $song->id]));
+        
+        // データベース確認にお気に入りとして保存されていないことを確認
+        $this->assertDatabaseMissing("favorites", [
+            "user_id" => $user->id,
+            "song_id" => $song->id,
+        ]);
+    }
+}
+

--- a/tests/Feature/SaveSongRequestTest.php
+++ b/tests/Feature/SaveSongRequestTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Response;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+
+use App\User;
+use App\Song;
+
+class SaveSongRequestTest extends TestCase
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+     
+    use RefreshDatabase;
+    use WithoutMiddleware;
+    
+    public function test_user_can_see_song_post_page()
+    {   
+        $this->withoutExceptionHandling();
+        
+        // ユーザーを1人作成
+        $user = factory(User::class)->create();
+        
+        //曲の投稿画面を表示する
+        $response = $this->actingAs($user)->get(route("songs.create"));
+        $response->assertStatus(200);
+    }
+    
+    public function test_request_should_pass_when_data_is_provided()
+    {
+        // ユーザーを1人作成
+        $user = factory(User::class)->create();
+        
+        //曲を投稿する
+        $response = $this->actingAs($user)->post(route("songs.store"),[
+            "title" => "AAA",
+            "artist_name" => "BBB",
+            "music_age" => 1970,
+        ]);
+
+        // プロフィール画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route('users.show',["id" => $user->id]));
+        
+        // データベースに曲が保存されていることを確認
+        $this->assertDatabaseHas('songs', [
+            "title" => "AAA",
+            "artist_name" => "BBB",
+            "music_age" => 1970,
+        ]);
+    }
+    
+    public function test_request_should_fail_when_no_title_is_provided()
+    {   
+        // ユーザーを1人作成
+        $user = factory(User::class)->create();
+        
+        //曲名を空白にして曲の投稿を試みる
+        $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
+            "title" => "",
+            "artist_name" => "BBB",
+            "music_age" => 1970,
+        ]);
+        
+        // 同画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route("songs.create"));
+        
+        // データベースに曲が存在しないことを確認
+        $this->assertDatabaseMissing('songs', [
+            "title" => "",
+            "artist_name" => "BBB",
+            "music_age" => 1970,
+        ]);
+        
+    }
+    
+    public function test_request_should_fail_when_no_artist_name_is_provided()
+    {   
+        // ユーザーを1人作成
+        $user = factory(User::class)->create();
+        
+        //アーティスト名を空白にして曲投稿を試みる
+        $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
+            "title" => "AAA",
+            "artist_name" => "",
+            "music_age" => 1970,
+        ]);
+        
+        // 同画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route("songs.create"));
+        
+        // データベースに曲が存在しないことを確認
+        $this->assertDatabaseMissing('songs', [
+            "title" => "AAA",
+            "artist_name" => "",
+            "music_age" => 1970,
+        ]);
+        
+    }
+    
+    public function test_request_should_fail_when_no_music_age_is_provided()
+    {   
+         // ユーザーを1人作成
+        $user = factory(User::class)->create();
+        
+        $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
+            "title" => "AAA",
+            "artist_name" => "BBB",
+            "music_age" => "",
+        ]);
+        
+        // 同画面に戻る
+        $response->assertStatus(302);
+        $response->assertRedirect(route("songs.create"));
+        
+        // データベースに曲が存在しないことを確認
+        $this->assertDatabaseMissing('songs', [
+            "title" => "AAA",
+            "artist_name" => "BBB",
+            "music_age" => "",
+        ]);
+    }
+    
+}


### PR DESCRIPTION
**概要**
- ファクトリSongFactoryを作成しました。
- 曲投稿機能・お気に入り機能のテストを作成しました。

**テストの内容**
 **SaveSongRequestTest**
- 曲投稿画面の表示
- 必須項目である「曲名」・「アーティスト名」・「曲の年代」を全て埋めれば投稿が成功
- 必須項目が一つでも空白だと投稿は失敗

**FavoriteTest**
- 曲をお気に入り登録
- お気に入り登録している曲をお気に入りから外す

**その他**
メンターが多忙のため、コードレビューはなし（9/23~）