### PR TITLE
マイプロフィールを更新するAPI作成/Userモデルにてブラックリスト方式に変更し、編集を認めないカラムを設定#62

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Controllers\Api;
 
-
 use Illuminate\Http\Request;
-
+use App\Http\Requests\UpdateUserRequest;
 
 use App\User;
 use App\Song;
@@ -61,9 +60,17 @@ class UsersController extends Controller
         );
         return \Route::dispatch($token);
     }
+
     // ユーザー一覧取得
     public function index(Request $request) {
         $users = User::all();
         return $users->toJson();
+    }
+
+    // ユーザー情報更新
+    public function update(UpdateUserRequest $request, $id)
+    {   
+        $user = User::find($id);
+        $user->update($request->all());
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -18,7 +18,6 @@ class User extends Authenticatable
     protected $guarded = [
         'id',
         'role',
-        'password',
         'created_at',
         'updated_at'
     ];

--- a/app/User.php
+++ b/app/User.php
@@ -15,8 +15,12 @@ class User extends Authenticatable
      *
      * @var array
      */
-    protected $fillable = [
-        "name", "email", "password", "age", "gender", "image_url", "favorite_music_age", "favorite_artist", "comment",
+    protected $guarded = [
+        'id',
+        'role',
+        'password',
+        'created_at',
+        'updated_at'
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,4 +24,6 @@ Route::post('signup', 'Api\UsersController@create');
 Route::group(['middleware' => ['auth:api']], function () {
     // ユーザー一覧取得
     Route::get('users', 'Api\UsersController@index');
+    // ユーザー情報更新
+    Route::put('user/update/{id}', 'Api\UsersController@update');
 });


### PR DESCRIPTION
- ログインユーザー自身のプロフィールを更新できるようAPIを作成。ルーティングおよびアクションを記述。

- 既存のUpdateUserRequestを用いて、バリデーションを実行。

- Userモデルにて、編集可能なカラムを設定する「ホワイトリスト方式」から、編集を認めない絡むを設定する「ブラックリスト方式」へと変更。また、パスワードが編集可能になっていたのはまずいので、編集を認めないように修正。
