### PR TITLE
曲をお気に入り追加・除外するAPIを作成/曲詳細を返すAPI（ログイン中ユーザーにお気に入り登録されているか否かの真偽値も含む）を作成  issue#73 #74

### DIFF
--- a/app/Http/Controllers/Api/FavoritesController.php
+++ b/app/Http/Controllers/Api/FavoritesController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+
+use App\Song;
+
+use App\Http\Controllers\Controller;
+
+class FavoritesController extends Controller
+{
+    // 曲をお気に入りに登録
+    public function bookmark(Request $request, $id)
+    {
+        \Auth::user()->favorite($id);
+    }
+
+    // 曲をお気に入りから外す
+    public function removeBookmark(Request $request, $id)
+    {
+        \Auth::user()->unfavorite($id);
+    }
+}

--- a/app/Http/Controllers/Api/SongsController.php
+++ b/app/Http/Controllers/Api/SongsController.php
@@ -10,23 +10,12 @@ use App\Song;
 
 use App\Http\Controllers\Controller;
 
-use Log;
-
 class SongsController extends Controller
 {      
     // 曲情報取得
     public function show($id) {
         $user = \Auth::user();
         $song = Song::find($id);
-        Log::debug('song="'.$song.'"');
-        // $exist = $this->is_favoriting($id);
-        // if ($exist){
-        //     'favoriting' = true;
-        // } else {
-        //     'favoriting' = false;
-        // }
-        // $song -> attach('favoriting');
-        // return $song->append('is_bookmarked')->toJson();
         return $song->toJson();
     }
 

--- a/app/Http/Controllers/Api/SongsController.php
+++ b/app/Http/Controllers/Api/SongsController.php
@@ -10,8 +10,26 @@ use App\Song;
 
 use App\Http\Controllers\Controller;
 
+use Log;
+
 class SongsController extends Controller
-{   
+{      
+    // 曲情報取得
+    public function show($id) {
+        $user = \Auth::user();
+        $song = Song::find($id);
+        Log::debug('song="'.$song.'"');
+        // $exist = $this->is_favoriting($id);
+        // if ($exist){
+        //     'favoriting' = true;
+        // } else {
+        //     'favoriting' = false;
+        // }
+        // $song -> attach('favoriting');
+        // return $song->append('is_bookmarked')->toJson();
+        return $song->toJson();
+    }
+
     // 曲一覧取得
     public function index(Request $request) {
         $songs = Song::all();

--- a/app/Song.php
+++ b/app/Song.php
@@ -17,12 +17,15 @@ class Song extends Model
         "deleted_at"
     ];
 
+    // ログインユーザーによりお気に入り登録されているか否かという真偽値をJSONに追加
+    protected $appends = ['is_bookmarked'];
+
     public function user()
     {
         return $this->belongsTo(User::class);
     }
     
-    public function favorite_users()
+    public function bookmarking_users()
     {
         return $this->belongsToMany(User::class, "favorites", "song_id", "user_id");
     }
@@ -30,5 +33,22 @@ class Song extends Model
     public function comments()
     {
         return $this->hasMany(Comment::class);
+    }
+    // ログインユーザーがお気に入り登録している
+    public function is_bookmarked()
+    {   
+        $user = \Auth::user();
+        $userId = $user->id;
+        return $this->bookmarking_users()->where("user_id", $userId)->exists();
+    }
+    // ログインユーザーにお気に入り登録されているか否かを返すためのアクセサ
+    public function getIsBookmarkedAttribute()
+    {
+        $exist = $this->is_bookmarked();
+        if ($exist){
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,8 @@ Route::group(['middleware' => ['auth:api']], function () {
     Route::get('/user/{id}', 'Api\UsersController@show');
     // ユーザー情報更新
     Route::put('user/update/{id}', 'Api\UsersController@update');
+    // 曲の情報を取得
+    Route::get('song/{id}', 'Api\SongsController@show');
     // 曲一覧取得
     Route::get('songs', 'Api\SongsController@index');
     // 曲の追加
@@ -36,4 +38,8 @@ Route::group(['middleware' => ['auth:api']], function () {
     Route::put('song/{id}', 'Api\SongsController@update');
     // 曲の削除
     Route::delete('song/{id}', 'Api\SongsController@destroy');
+    // 曲のお気に入り登録
+    Route::post('song/{id}/bookmark', 'Api\FavoritesController@bookmark');
+    // 曲のお気に入りから外す
+    Route::post('song/{id}/removeBookmark', 'Api\FavoritesController@removeBookmark');
 });


### PR DESCRIPTION
 - 曲をお気に入り追加・除外するAPIを作成

- 曲が、ログイン中ユーザーによりお気に入り登録されているものであるか否かという真偽値をsongのJSONに追加。

　　- モデルSongにてアクセサを作成し、真偽値is_bookmarkedをJSONに追加した。

- 曲詳細（作成したis_bookmarkedを含むJSON）を返すAPIを作成した。

