### PR TITLE
曲を追加・更新時にis_bookmarkedが含まれてエラーが出る点を修正 issue#76

### DIFF
--- a/app/Http/Controllers/Api/SongsController.php
+++ b/app/Http/Controllers/Api/SongsController.php
@@ -16,27 +16,30 @@ class SongsController extends Controller
     public function show($id) {
         $user = \Auth::user();
         $song = Song::find($id);
-        return $song->toJson();
+        return $song->append('is_bookmarked')->toJson();
     }
 
     // 曲一覧取得
     public function index(Request $request) {
         $songs = Song::all();
-        return $songs->toJson();
+        return $songs->transform(function($songs) {
+            return $songs->append('is_bookmarked');
+        })
+        ->toJson();
     }
 
     // 曲の追加
     public function store(CreateSongRequest $request)
     {   
         $user = \Auth::user();
-        $user->songs()->create($request->all());
+        $user->songs()->create($request->validated());
     }
 
     // 曲の更新
     public function update(UpdateSongRequest $request, $id)
     {
         $song = Song::find($id);
-        $song->update($request->all());
+        $song->update($request->validated());
     }
 
     // 曲の削除

--- a/app/Song.php
+++ b/app/Song.php
@@ -17,9 +17,6 @@ class Song extends Model
         "deleted_at"
     ];
 
-    // ログインユーザーによりお気に入り登録されているか否かという真偽値をJSONに追加
-    protected $appends = ['is_bookmarked'];
-
     public function user()
     {
         return $this->belongsTo(User::class);


### PR DESCRIPTION
- モデルsongにてis_bookmarkedのappendを削除。

- SongsControllerのアクションshow・indexで返すJSONに個別にis_bookmarkedを追加

- SongsControllerのアクションstore・updateにおいてフォームリクエストが適用されるように修正。