### PR TITLE
曲へのコメント投稿・編集・削除機能の作成/曲のshow・indexアクション（API）にてコメント一覧のJSONを含めた #82

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -6,9 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class Comment extends Model
 {
-    
-    protected $fillable = [
-        "body", "user_id", "song_id",
+    protected $guarded = [
+        'id',
+        'created_at',
+        'updated_at',
     ];
     
     public function song()

--- a/app/Http/Controllers/Api/CommentsController.php
+++ b/app/Http/Controllers/Api/CommentsController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\CreateCommentRequest;
+
+use App\Comment;
+use App\Song;
+
+use App\Http\Controllers\Controller;
+
+use Log;
+
+class CommentsController extends Controller
+{      
+    // public function store(CreateCommentRequest $request, $id)
+    public function store(Request $request, $sid)
+    {
+        $user = \Auth::user();
+        $song = Song::find($sid);
+        // Log::debug($song);
+        // $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
+        $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
+        // $song->comments()->create($request->validated());
+        $song->comments()->create($request->all());
+    }
+    public function update(Request $request, $sid, $cid)
+    {
+        $user = \Auth::user();
+        $song = Song::find($sid);
+        // Log::debug($song);
+        // $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
+        $comment = Comment::find($cid);
+        Log::debug($comment);
+        $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
+        Log::debug($request);
+        // $song->comments()->create($request->validated());
+        $comment->update($request->all());
+    }
+ 
+    public function destroy($cid)
+    {
+        $comment = Comment::find($cid);
+        
+        if(\Auth::id() === $comment->user_id){
+            $comment->delete();
+        }
+    }
+}

--- a/app/Http/Controllers/Api/CommentsController.php
+++ b/app/Http/Controllers/Api/CommentsController.php
@@ -13,29 +13,22 @@ use App\Http\Controllers\Controller;
 use Log;
 
 class CommentsController extends Controller
-{      
-    // public function store(CreateCommentRequest $request, $id)
+{
     public function store(Request $request, $sid)
     {
         $user = \Auth::user();
         $song = Song::find($sid);
-        // Log::debug($song);
-        // $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
         $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
-        // $song->comments()->create($request->validated());
         $song->comments()->create($request->all());
     }
     public function update(Request $request, $sid, $cid)
     {
         $user = \Auth::user();
         $song = Song::find($sid);
-        // Log::debug($song);
-        // $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
         $comment = Comment::find($cid);
         Log::debug($comment);
         $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
         Log::debug($request);
-        // $song->comments()->create($request->validated());
         $comment->update($request->all());
     }
  

--- a/app/Http/Controllers/Api/CommentsController.php
+++ b/app/Http/Controllers/Api/CommentsController.php
@@ -10,8 +10,6 @@ use App\Song;
 
 use App\Http\Controllers\Controller;
 
-use Log;
-
 class CommentsController extends Controller
 {
     public function store(Request $request, $sid)
@@ -26,9 +24,7 @@ class CommentsController extends Controller
         $user = \Auth::user();
         $song = Song::find($sid);
         $comment = Comment::find($cid);
-        Log::debug($comment);
         $request->merge(['user_id' => $user->id, 'song_id' => $song->id]);
-        Log::debug($request);
         $comment->update($request->all());
     }
  

--- a/app/Http/Controllers/Api/SongsController.php
+++ b/app/Http/Controllers/Api/SongsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use Illuminate\Http\Request;
 use App\Http\Requests\CreateSongRequest;
 use App\Http\Requests\UpdateSongRequest;
+use App\Http\Requests\CreateCommentRequest;
 
 use App\Song;
 
@@ -16,7 +17,7 @@ class SongsController extends Controller
     public function index(Request $request) {
         $songs = Song::all();
         return $songs->transform(function($songs) {
-            return $songs->append(['is_bookmarked', 'bookmarking_users']);
+            return $songs->append(['is_bookmarked', 'bookmarking_users', 'comments']);
         })
         ->toJson();
     }
@@ -25,7 +26,7 @@ class SongsController extends Controller
     public function show($id) {
         $user = \Auth::user();
         $song = Song::find($id);
-        return $song->append(['is_bookmarked', 'bookmarking_users'])->toJson();
+        return $song->append(['is_bookmarked', 'bookmarking_users', 'comments'])->toJson();
     }
 
     // 曲の追加

--- a/app/Http/Requests/CreateCommentRequest.php
+++ b/app/Http/Requests/CreateCommentRequest.php
@@ -24,8 +24,6 @@ class CreateCommentRequest extends FormRequest
     public function rules()
     {
         return [
-            "user_id" => "required",
-            "song_id" => "required",
             "body" => "required|max:400",
         ];
     }

--- a/app/Song.php
+++ b/app/Song.php
@@ -54,4 +54,10 @@ class Song extends Model
     {
         return $this->bookmarking_users()->get();
     }
+
+    // 曲へのコメント一覧を返すためのアクセサ
+    public function getCommentsAttribute()
+    {
+        return $this->comments()->get();
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,4 +46,10 @@ Route::group(['middleware' => ['auth:api']], function () {
     Route::post('song/{id}/bookmark', 'Api\FavoritesController@bookmark');
     // 曲のお気に入りから外す
     Route::post('song/{id}/removeBookmark', 'Api\FavoritesController@removeBookmark');
+    // 曲へのコメントの投稿
+    Route::post('song/{sid}/comment', 'Api\CommentsController@store');
+    // 曲へのコメントの削除
+    Route::delete('comment/{cid}', 'Api\CommentsController@destroy');
+    // 曲へのコメントの更新
+    Route::put('song/{sid}/comment/{cid}', 'Api\CommentsController@update');
 });


### PR DESCRIPTION
**SongモデルおよびSongsController**

- fillableからguardedに変更。

- 曲へのコメントを返すためのアクセサgetCommentsAttributeを作成。

- SongsControllerのindexおよびshowアクションにおいて、返すJSONにcommentsを追加。

**コントローラCommentsControllerを作成**

- store/update/destroyアクションを作成。

- 曲のIDはsid・コメントのIDはcidで取得している。

- store/updateアクションにおいて、リクエストにユーザーのIDと曲のIDをmergeで含めている。