### PR TITLE
SPA化に伴い不要なルーティングを削除 #87

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,56 @@
-# PHP CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-php/ for more details
-#
-version: 2
-jobs:
-  build:
-    docker:
-      # Specify the version you desire here
-      - image: circleci/php:7.3-node-browsers
-      - image: circleci/mysql:5.7
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # Using the RAM variation mitigates I/O contention
-      # for database intensive operations.
-      # - image: circleci/mysql:5.7-ram
-      #
-      # - image: redis:2.8.19
-    environment:
-      - APP_DEBUG: true
-      - APP_ENV: testing
-      - APP_KEY: base64:Y8nMmWw0Z9EixnIgVA9xtvwuFc2Qde6ukS70Z2VOp7s=
-      - DB_CONNECTION: circle_test
-      - MYSQL_ALLOW_EMPTY_PASSWORD: true
-    working_directory: ~/repo
-    steps:
-      - checkout
-    # Install PHP Extension
-      - run: sudo docker-php-ext-install pdo_mysql
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            # "composer.lock" can be used if it is committed to the repo
-            - v1-dependencies-{{ checksum "composer.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-      - run: composer install -n --prefer-dist
-      - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
-          paths:
-            - ./vendor
-      - restore_cache:
-          keys:
-            - node-v1-{{ checksum "package.json" }}
-            - node-v1-
-      - run: yarn install
-      - save_cache:
-          key: node-v1-{{ checksum "package.json" }}
-          paths:
-            - node_modules
-      # run seeding
-      - run: php artisan migrate
-      - run: php artisan db:seed
-      # run tests!
-      - run: php ./vendor/bin/phpunit
+# # PHP CircleCI 2.0 configuration file
+# #
+# # Check https://circleci.com/docs/2.0/language-php/ for more details
+# #
+# version: 2
+# jobs:
+#   build:
+#     docker:
+#       # Specify the version you desire here
+#       - image: circleci/php:7.3-node-browsers
+#       - image: circleci/mysql:5.7
+#       # Specify service dependencies here if necessary
+#       # CircleCI maintains a library of pre-built images
+#       # documented at https://circleci.com/docs/2.0/circleci-images/
+#       # Using the RAM variation mitigates I/O contention
+#       # for database intensive operations.
+#       # - image: circleci/mysql:5.7-ram
+#       #
+#       # - image: redis:2.8.19
+#     environment:
+#       - APP_DEBUG: true
+#       - APP_ENV: testing
+#       - APP_KEY: base64:Y8nMmWw0Z9EixnIgVA9xtvwuFc2Qde6ukS70Z2VOp7s=
+#       - DB_CONNECTION: circle_test
+#       - MYSQL_ALLOW_EMPTY_PASSWORD: true
+#     working_directory: ~/repo
+#     steps:
+#       - checkout
+#     # Install PHP Extension
+#       - run: sudo docker-php-ext-install pdo_mysql
+#       # Download and cache dependencies
+#       - restore_cache:
+#           keys:
+#             # "composer.lock" can be used if it is committed to the repo
+#             - v1-dependencies-{{ checksum "composer.json" }}
+#             # fallback to using the latest cache if no exact match is found
+#             - v1-dependencies-
+#       - run: composer install -n --prefer-dist
+#       - save_cache:
+#           key: v1-dependencies-{{ checksum "composer.json" }}
+#           paths:
+#             - ./vendor
+#       - restore_cache:
+#           keys:
+#             - node-v1-{{ checksum "package.json" }}
+#             - node-v1-
+#       - run: yarn install
+#       - save_cache:
+#           key: node-v1-{{ checksum "package.json" }}
+#           paths:
+#             - node_modules
+#       # run seeding
+#       - run: php artisan migrate
+#       - run: php artisan db:seed
+#       # run tests!
+#       - run: php ./vendor/bin/phpunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,56 @@
-# # PHP CircleCI 2.0 configuration file
-# #
-# # Check https://circleci.com/docs/2.0/language-php/ for more details
-# #
-# version: 2
-# jobs:
-#   build:
-#     docker:
-#       # Specify the version you desire here
-#       - image: circleci/php:7.3-node-browsers
-#       - image: circleci/mysql:5.7
-#       # Specify service dependencies here if necessary
-#       # CircleCI maintains a library of pre-built images
-#       # documented at https://circleci.com/docs/2.0/circleci-images/
-#       # Using the RAM variation mitigates I/O contention
-#       # for database intensive operations.
-#       # - image: circleci/mysql:5.7-ram
-#       #
-#       # - image: redis:2.8.19
-#     environment:
-#       - APP_DEBUG: true
-#       - APP_ENV: testing
-#       - APP_KEY: base64:Y8nMmWw0Z9EixnIgVA9xtvwuFc2Qde6ukS70Z2VOp7s=
-#       - DB_CONNECTION: circle_test
-#       - MYSQL_ALLOW_EMPTY_PASSWORD: true
-#     working_directory: ~/repo
-#     steps:
-#       - checkout
-#     # Install PHP Extension
-#       - run: sudo docker-php-ext-install pdo_mysql
-#       # Download and cache dependencies
-#       - restore_cache:
-#           keys:
-#             # "composer.lock" can be used if it is committed to the repo
-#             - v1-dependencies-{{ checksum "composer.json" }}
-#             # fallback to using the latest cache if no exact match is found
-#             - v1-dependencies-
-#       - run: composer install -n --prefer-dist
-#       - save_cache:
-#           key: v1-dependencies-{{ checksum "composer.json" }}
-#           paths:
-#             - ./vendor
-#       - restore_cache:
-#           keys:
-#             - node-v1-{{ checksum "package.json" }}
-#             - node-v1-
-#       - run: yarn install
-#       - save_cache:
-#           key: node-v1-{{ checksum "package.json" }}
-#           paths:
-#             - node_modules
-#       # run seeding
-#       - run: php artisan migrate
-#       - run: php artisan db:seed
-#       # run tests!
-#       - run: php ./vendor/bin/phpunit
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # Specify the version you desire here
+      - image: circleci/php:7.3-node-browsers
+      - image: circleci/mysql:5.7
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # Using the RAM variation mitigates I/O contention
+      # for database intensive operations.
+      # - image: circleci/mysql:5.7-ram
+      #
+      # - image: redis:2.8.19
+    environment:
+      - APP_DEBUG: true
+      - APP_ENV: testing
+      - APP_KEY: base64:Y8nMmWw0Z9EixnIgVA9xtvwuFc2Qde6ukS70Z2VOp7s=
+      - DB_CONNECTION: circle_test
+      - MYSQL_ALLOW_EMPTY_PASSWORD: true
+    working_directory: ~/repo
+    steps:
+      - checkout
+    # Install PHP Extension
+      - run: sudo docker-php-ext-install pdo_mysql
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+      - run: composer install -n --prefer-dist
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "package.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      # run seeding
+      - run: php artisan migrate
+      - run: php artisan db:seed
+      # run tests!
+      - run: php ./vendor/bin/phpunit

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,74 +11,74 @@
 |
 */
 
-// 未ログイン時
-Route::group(["middleware" => "guest"], function(){
-    // 未ログイン時のトップページ
-    Route::get("/", "WelcomeController@welcome")->name("welcome");
+// // 未ログイン時
+// Route::group(["middleware" => "guest"], function(){
+//     // 未ログイン時のトップページ
+//     Route::get("/", "WelcomeController@welcome")->name("welcome");
     
-    // ユーザ登録
-    Route::get("signup", "Auth\RegisterController@showRegistrationForm")->name("signup.get");
-    Route::post("signup", "Auth\RegisterController@register")->name("signup.post");
+//     // ユーザ登録
+//     Route::get("signup", "Auth\RegisterController@showRegistrationForm")->name("signup.get");
+//     Route::post("signup", "Auth\RegisterController@register")->name("signup.post");
     
-    // ログイン認証
-    Route::get("login", "Auth\LoginController@showLoginForm")->name("login");
-    Route::post("login", "Auth\LoginController@login")->name("login.post");
+//     // ログイン認証
+//     Route::get("login", "Auth\LoginController@showLoginForm")->name("login");
+//     Route::post("login", "Auth\LoginController@login")->name("login.post");
     
-    // SNS認証
-    Route::get("login/{provider}", "Auth\SocialAccountController@redirectToProvider")->name("socialOAuth");
-    Route::get("login/{provider}/callback", "Auth\SocialAccountController@handleProviderCallback")->name("oauthCallback");
+//     // SNS認証
+//     Route::get("login/{provider}", "Auth\SocialAccountController@redirectToProvider")->name("socialOAuth");
+//     Route::get("login/{provider}/callback", "Auth\SocialAccountController@handleProviderCallback")->name("oauthCallback");
    
-});
+// });
 
-// ログインしている全ユーザー
-Route::group(["middleware" => ["auth", "can:user-higher"]], function(){
-    // ログイン時のトップページ
-    Route::get("/home", "SongsController@index")->name("home");
+// // ログインしている全ユーザー
+// Route::group(["middleware" => ["auth", "can:user-higher"]], function(){
+//     // ログイン時のトップページ
+//     Route::get("/home", "SongsController@index")->name("home");
     
-    // ログアウト
-    Route::get("logout", "Auth\LoginController@logout")->name("logout.get");
+//     // ログアウト
+//     Route::get("logout", "Auth\LoginController@logout")->name("logout.get");
     
-    // ユーザープロフィール詳細・マイプロフィール編集・マイプロフィール更新
-    Route::resource("users", "UsersController", ["only" => ["show", "edit", "update"]]);
+//     // ユーザープロフィール詳細・マイプロフィール編集・マイプロフィール更新
+//     Route::resource("users", "UsersController", ["only" => ["show", "edit", "update"]]);
     
-    // 曲の一覧表示・登録画面表示・登録処理・取得表示・更新画面表示・更新処理・削除処理
-    Route::resource("songs", "SongsController");
+//     // 曲の一覧表示・登録画面表示・登録処理・取得表示・更新画面表示・更新処理・削除処理
+//     Route::resource("songs", "SongsController");
     
-    // 曲へのコメントの投稿・削除
-    Route::resource("comments", "CommentsController", ["only" =>["store", "destroy"]]);
+//     // 曲へのコメントの投稿・削除
+//     Route::resource("comments", "CommentsController", ["only" =>["store", "destroy"]]);
     
-    Route::group(["prefix" => "users/{id}"], function(){
-        Route::post("follow", "UserFollowController@store")->name("user.follow");
-        Route::delete("unfollow", "UserFollowController@destroy")->name("user.unfollow");
-        Route::get("followings", "UsersController@followings")->name("users.followings");
-        Route::get("followers", "UsersController@followers")->name("users.followers");
-        Route::get("favorites", "UsersController@favorites")->name("users.favorites");
-        Route::get("images", "UserImagesController@uploadForm")->name("users.imagesUploadForm");
-        Route::post("images", "UserImagesController@upload")->name("users.imagesUpload");
-    });
+//     Route::group(["prefix" => "users/{id}"], function(){
+//         Route::post("follow", "UserFollowController@store")->name("user.follow");
+//         Route::delete("unfollow", "UserFollowController@destroy")->name("user.unfollow");
+//         Route::get("followings", "UsersController@followings")->name("users.followings");
+//         Route::get("followers", "UsersController@followers")->name("users.followers");
+//         Route::get("favorites", "UsersController@favorites")->name("users.favorites");
+//         Route::get("images", "UserImagesController@uploadForm")->name("users.imagesUploadForm");
+//         Route::post("images", "UserImagesController@upload")->name("users.imagesUpload");
+//     });
     
-    Route::group(["prefix" => "songs/{id}"], function(){
-        Route::post("favorite", "FavoritesController@store")->name("favorites.favorite");
-        Route::delete("unfavorite", "FavoritesController@destroy")->name("favorites.unfavorite");
-        Route::get("images", "SongImagesController@uploadForm")->name("songs.imagesUploadForm");
-        Route::post("images", "SongImagesController@upload")->name("songs.imagesUpload");
-    });
+//     Route::group(["prefix" => "songs/{id}"], function(){
+//         Route::post("favorite", "FavoritesController@store")->name("favorites.favorite");
+//         Route::delete("unfavorite", "FavoritesController@destroy")->name("favorites.unfavorite");
+//         Route::get("images", "SongImagesController@uploadForm")->name("songs.imagesUploadForm");
+//         Route::post("images", "SongImagesController@upload")->name("songs.imagesUpload");
+//     });
     
-    Route::group(["prefix" => "search"], function(){
-        // ユーザーの検索機能
-        Route::get("users", "UsersController@search")->name("users.search");
-        // 曲の検索機能
-        Route::get("songs", "SongsController@search")->name("songs.search");
-    });
+//     Route::group(["prefix" => "search"], function(){
+//         // ユーザーの検索機能
+//         Route::get("users", "UsersController@search")->name("users.search");
+//         // 曲の検索機能
+//         Route::get("songs", "SongsController@search")->name("songs.search");
+//     });
     
-    // YouTubeのキーワード検索機能
-    Route::get("youtube", "YouTubeController@index")->name("youtube.index");
-});
+//     // YouTubeのキーワード検索機能
+//     Route::get("youtube", "YouTubeController@index")->name("youtube.index");
+// });
 
-// 管理者権限機能
-Route::group(["middleware" => ["auth", "can:admin-higher"]], function(){
-        Route::get("index-for-admin", "SongsController@indexForAdmin")->name("songs.indexForAdmin");
-        Route::get("delete/{id}", "SongsController@delete")->name("songs.delete");
-        Route::get("restore/{id}", "SongsController@restore")->name("songs.restore");
-        Route::get("force-delete/{id}", "SongsController@forceDelete")->name("songs.forceDelete");
-});
+// // 管理者権限機能
+// Route::group(["middleware" => ["auth", "can:admin-higher"]], function(){
+//         Route::get("index-for-admin", "SongsController@indexForAdmin")->name("songs.indexForAdmin");
+//         Route::get("delete/{id}", "SongsController@delete")->name("songs.delete");
+//         Route::get("restore/{id}", "SongsController@restore")->name("songs.restore");
+//         Route::get("force-delete/{id}", "SongsController@forceDelete")->name("songs.forceDelete");
+// });

--- a/tests/Feature/CommentsTest.php
+++ b/tests/Feature/CommentsTest.php
@@ -1,79 +1,79 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Foundation\Testing\WithoutMiddleware;
 
-use App\User;
-use App\Song;
-use App\Comment;
+// use App\User;
+// use App\Song;
+// use App\Comment;
 
-class CommentsTest extends TestCase
-{
-    /**
-     * A basic test example.
-     *
-     * @return void
-     */
+// class CommentsTest extends TestCase
+// {
+//     /**
+//      * A basic test example.
+//      *
+//      * @return void
+//      */
      
-    use RefreshDatabase;
-    use WithoutMiddleware;
+//     use RefreshDatabase;
+//     use WithoutMiddleware;
      
-    public function test_user_can_post_comment()
-    {
-        // ユーザーを１人作成する
-        $user = factory(User::class)->create();
+//     public function test_user_can_post_comment()
+//     {
+//         // ユーザーを１人作成する
+//         $user = factory(User::class)->create();
         
-        // 曲を１つ作成する
-        $song = factory(Song::class)->create();
+//         // 曲を１つ作成する
+//         $song = factory(Song::class)->create();
         
-        // 曲にコメントを投稿する
-        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("comments.store"), [
-            "user_id" => $user->id,
-            "song_id" => $song->id,
-            "body" => "aaa",
-        ]);
+//         // 曲にコメントを投稿する
+//         $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("comments.store"), [
+//             "user_id" => $user->id,
+//             "song_id" => $song->id,
+//             "body" => "aaa",
+//         ]);
         
-        // 同画面にリダイレクト
-        $response->assertStatus(302);
-        // $response->assertRedirect("songs/{$song->id}");
-        $response->assertRedirect(route("songs.show",["id" => $song->id]));
+//         // 同画面にリダイレクト
+//         $response->assertStatus(302);
+//         // $response->assertRedirect("songs/{$song->id}");
+//         $response->assertRedirect(route("songs.show",["id" => $song->id]));
         
-        $this->assertDatabaseHas("comments", [
-            "user_id" => $user->id,
-            "song_id" => $song->id,
-            "body" => "aaa",
-        ]);
-    }
+//         $this->assertDatabaseHas("comments", [
+//             "user_id" => $user->id,
+//             "song_id" => $song->id,
+//             "body" => "aaa",
+//         ]);
+//     }
     
-    public function test_user_can_delete_comment()
-    {   
-        // ユーザーを１人作成する
-        $user = factory(User::class)->create();
+//     public function test_user_can_delete_comment()
+//     {   
+//         // ユーザーを１人作成する
+//         $user = factory(User::class)->create();
         
-        // 曲を１つ作成する
-        $song = factory(Song::class)->create();
+//         // 曲を１つ作成する
+//         $song = factory(Song::class)->create();
         
-        // 曲にコメントを投稿する
-        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("comments.store"), [
-            "user_id" => $user->id,
-            "song_id" => $song->id,
-            "body" => "aaa",
-        ]);
+//         // 曲にコメントを投稿する
+//         $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("comments.store"), [
+//             "user_id" => $user->id,
+//             "song_id" => $song->id,
+//             "body" => "aaa",
+//         ]);
         
-        // 自分が投稿したコメントを削除する
-        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->delete(route("comments.destroy", ["id" => $song->id]));
+//         // 自分が投稿したコメントを削除する
+//         $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->delete(route("comments.destroy", ["id" => $song->id]));
            
-        // 同画面にリダイレクト
-        $response->assertStatus(302);
-        $response->assertRedirect(route("songs.show",["id" => $song->id]));
+//         // 同画面にリダイレクト
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("songs.show",["id" => $song->id]));
         
-        $this->assertDatabaseMissing("comments", [
-            "user_id" => $user->id,
-            "song_id" => $song->id,
-        ]);
-    }
-}
+//         $this->assertDatabaseMissing("comments", [
+//             "user_id" => $user->id,
+//             "song_id" => $song->id,
+//         ]);
+//     }
+// }

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
 
-class ExampleTest extends TestCase
-{
-    /**
-     * A basic test example.
-     *
-     * @return void
-     */
-    public function testBasicTest()
-    {
-        $response = $this->get('/');
+// class ExampleTest extends TestCase
+// {
+//     /**
+//      * A basic test example.
+//      *
+//      * @return void
+//      */
+//     public function testBasicTest()
+//     {
+//         $response = $this->get('/');
 
-        $response->assertStatus(200);
-    }
-}
+//         $response->assertStatus(200);
+//     }
+// }

--- a/tests/Feature/FavoriteTest.php
+++ b/tests/Feature/FavoriteTest.php
@@ -1,71 +1,71 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Foundation\Testing\WithoutMiddleware;
 
-use App\User;
-use App\Song;
+// use App\User;
+// use App\Song;
 
-class FavoriteTest extends TestCase
-{
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
+// class FavoriteTest extends TestCase
+// {
+//     /**
+//      * A basic feature test example.
+//      *
+//      * @return void
+//      */
     
-    use RefreshDatabase;
-    use WithoutMiddleware;
+//     use RefreshDatabase;
+//     use WithoutMiddleware;
     
-    public function test_user_can_add_song_to_favorites()
-    {
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_user_can_add_song_to_favorites()
+//     {
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        //曲を1つ作成
-        $song = factory(Song::class)->create();
+//         //曲を1つ作成
+//         $song = factory(Song::class)->create();
         
-        //曲をお気に入り登録する
-        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("favorites.favorite", ["id" => $song->id]));
+//         //曲をお気に入り登録する
+//         $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("favorites.favorite", ["id" => $song->id]));
         
-        // 同じ画面にリダイレクト
-        $response->assertStatus(302);
-        $response->assertRedirect(route("songs.show", ["id" => $song->id]));
+//         // 同じ画面にリダイレクト
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("songs.show", ["id" => $song->id]));
         
-        // データベースにお気に入りとして保存されていることを確認
-        $this->assertDatabaseHas("favorites", [
-            "user_id" => $user->id,
-            "song_id" => $song->id,
-        ]);
-    }
+//         // データベースにお気に入りとして保存されていることを確認
+//         $this->assertDatabaseHas("favorites", [
+//             "user_id" => $user->id,
+//             "song_id" => $song->id,
+//         ]);
+//     }
     
-    public function test_user_can_remove_song_from_favorites()
-    {
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_user_can_remove_song_from_favorites()
+//     {
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        //曲を1つ作成
-        $song = factory(Song::class)->create();
+//         //曲を1つ作成
+//         $song = factory(Song::class)->create();
         
-        //曲をお気に入り登録する
-        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("favorites.favorite", ["id" => $song->id]));
+//         //曲をお気に入り登録する
+//         $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->post(route("favorites.favorite", ["id" => $song->id]));
         
-        //曲をお気に入りから外す
-        $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->delete(route("favorites.unfavorite", ["id" => $song->id]));
+//         //曲をお気に入りから外す
+//         $response = $this->actingAs($user)->from(route("songs.show", ["id" => $song->id]))->delete(route("favorites.unfavorite", ["id" => $song->id]));
         
-        // 同じ画面にリダイレクト
-        $response->assertStatus(302);
-        $response->assertRedirect(route("songs.show", ["id" => $song->id]));
+//         // 同じ画面にリダイレクト
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("songs.show", ["id" => $song->id]));
         
-        // データベース確認にお気に入りとして保存されていないことを確認
-        $this->assertDatabaseMissing("favorites", [
-            "user_id" => $user->id,
-            "song_id" => $song->id,
-        ]);
-    }
-}
+//         // データベース確認にお気に入りとして保存されていないことを確認
+//         $this->assertDatabaseMissing("favorites", [
+//             "user_id" => $user->id,
+//             "song_id" => $song->id,
+//         ]);
+//     }
+// }
 

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -1,82 +1,82 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Foundation\Testing\WithoutMiddleware;
 
-use App\User;
+// use App\User;
 
-use Auth;
+// use Auth;
 
-class LoginTest extends TestCase
-{
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
+// class LoginTest extends TestCase
+// {
+//     /**
+//      * A basic feature test example.
+//      *
+//      * @return void
+//      */
      
-    use RefreshDatabase;
-    use WithoutMiddleware;
+//     use RefreshDatabase;
+//     use WithoutMiddleware;
     
-    public function test_user_can_see_login_page()
-    {   
-        $response = $this->get(route("login"));
+//     public function test_user_can_see_login_page()
+//     {   
+//         $response = $this->get(route("login"));
 
-        $response->assertStatus(200);
-    }
+//         $response->assertStatus(200);
+//     }
     
-   /* public function test_valid_user_can_login()
-    {   
-        $this->withoutExceptionHandling();
+//    /* public function test_valid_user_can_login()
+//     {   
+//         $this->withoutExceptionHandling();
         
-        // ユーザーを１つ作成
-        $user = factory(User::class)->create([
-            "password" => bcrypt("test1111")
-        ]);
+//         // ユーザーを１つ作成
+//         $user = factory(User::class)->create([
+//             "password" => bcrypt("test1111")
+//         ]);
         
-        // まだ認証されていない
-        $this->assertFalse(Auth::check());
+//         // まだ認証されていない
+//         $this->assertFalse(Auth::check());
         
-        // dd($user->password);
+//         // dd($user->password);
         
-        // ログイン実行
-        $response = $this->from(route("login"))->post(route("login.post"), [
-            "email" => $user->email,
-            "password" => "test1111"
-        ]);
+//         // ログイン実行
+//         $response = $this->from(route("login"))->post(route("login.post"), [
+//             "email" => $user->email,
+//             "password" => "test1111"
+//         ]);
         
-        // 認証されている
-        $this->assertTrue(Auth::check());
+//         // 認証されている
+//         $this->assertTrue(Auth::check());
         
-        // ログイン後にトップページにリダイレクトされる
-        $response->assertStatus(302);
-        $response->assertRedirect(route("home"));
-    }
+//         // ログイン後にトップページにリダイレクトされる
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("home"));
+//     }
     
-    public function test_invalid_user_cannot_login()
-    {   
-        // ユーザーを１つ作成
-        $user = factory(User::class)->create([
-            "password" => bcrypt("test1111")
-        ]);
+//     public function test_invalid_user_cannot_login()
+//     {   
+//         // ユーザーを１つ作成
+//         $user = factory(User::class)->create([
+//             "password" => bcrypt("test1111")
+//         ]);
         
-        // まだ認証されていない
-        $this->assertFalse(Auth::check());
+//         // まだ認証されていない
+//         $this->assertFalse(Auth::check());
         
-        // 異なるパスワードでログイン実行
-        $response = $this->from(route("login"))->post(route("login.post"), [
-            "email" => $user->email,
-            "password" => "test2222"
-        ]);
+//         // 異なるパスワードでログイン実行
+//         $response = $this->from(route("login"))->post(route("login.post"), [
+//             "email" => $user->email,
+//             "password" => "test2222"
+//         ]);
         
-        // 認証失敗
-        $this->assertFalse(Auth::check());
+//         // 認証失敗
+//         $this->assertFalse(Auth::check());
         
-        // ログイン画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route("login"));
-    }*/
-}
+//         // ログイン画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("login"));
+//     }*/
+// }

--- a/tests/Feature/LogoutTest.php
+++ b/tests/Feature/LogoutTest.php
@@ -1,43 +1,43 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
 
-use App\User;
+// use App\User;
 
-use Auth;
+// use Auth;
 
-class LogoutTest extends TestCase
-{
-    /**
-     * A basic test example.
-     *
-     * @return void
-     */
+// class LogoutTest extends TestCase
+// {
+//     /**
+//      * A basic test example.
+//      *
+//      * @return void
+//      */
      
-    use RefreshDatabase;
+//     use RefreshDatabase;
      
-    public function test_logout()
-    {  
-        // ユーザーを１つ作成
-        $user = factory(User::class)->create();
+//     public function test_logout()
+//     {  
+//         // ユーザーを１つ作成
+//         $user = factory(User::class)->create();
         
-        // ログイン済み
-        $this->actingAs($user);
+//         // ログイン済み
+//         $this->actingAs($user);
         
-        // 認証済み
-        $this->assertTrue(Auth::check());
+//         // 認証済み
+//         $this->assertTrue(Auth::check());
         
-        // ログアウトを実行
-        $response = $this->get(route("logout.get"));
+//         // ログアウトを実行
+//         $response = $this->get(route("logout.get"));
         
-        // 認証されていない
-        $this->assertFalse(Auth::check());
+//         // 認証されていない
+//         $this->assertFalse(Auth::check());
         
-        // トップページにリダイレクト
-        $response->assertRedirect(route("welcome"));
-    }
-}
+//         // トップページにリダイレクト
+//         $response->assertRedirect(route("welcome"));
+//     }
+// }

--- a/tests/Feature/OAuthTest.php
+++ b/tests/Feature/OAuthTest.php
@@ -1,34 +1,34 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
 
-class OAuthTest extends TestCase
-{
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
+// class OAuthTest extends TestCase
+// {
+//     /**
+//      * A basic feature test example.
+//      *
+//      * @return void
+//      */
      
-     use RefreshDatabase;
+//      use RefreshDatabase;
      
-    public function test_user_can_see_OAuth_page()
-    {
-        $this->providerName = "github";
-        $this->get(route("socialOAuth", ["provider" => $this->providerName]))
-            ->assertStatus(302);
-    }
+//     public function test_user_can_see_OAuth_page()
+//     {
+//         $this->providerName = "github";
+//         $this->get(route("socialOAuth", ["provider" => $this->providerName]))
+//             ->assertStatus(302);
+//     }
     
-    public function test_user_can_signup_width_github_account()
-    {
-        $this->providerName = "github";
+//     public function test_user_can_signup_width_github_account()
+//     {
+//         $this->providerName = "github";
          
-        // URLをコール
-        $this->get(route("oauthCallback", ["provider" => $this->providerName]))
-            ->assertStatus(302);
-    }
-}
+//         // URLをコール
+//         $this->get(route("oauthCallback", ["provider" => $this->providerName]))
+//             ->assertStatus(302);
+//     }
+// }

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -1,144 +1,144 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Foundation\Testing\WithoutMiddleware;
 
-use Hash;
+// use Hash;
 
-use App\User;
+// use App\User;
 
-use Auth;
+// use Auth;
 
-class RegisterTest extends TestCase
-{
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
+// class RegisterTest extends TestCase
+// {
+//     /**
+//      * A basic feature test example.
+//      *
+//      * @return void
+//      */
      
-    use RefreshDatabase;
-    use WithoutMiddleware;
+//     use RefreshDatabase;
+//     use WithoutMiddleware;
     
-    public function test_user_can_see_signup_page()
-    {   
-        //ユーザー登録画面を表示する
-        $response = $this->get(route("signup.get"));
-        $response->assertStatus(200);
-    }
+//     public function test_user_can_see_signup_page()
+//     {   
+//         //ユーザー登録画面を表示する
+//         $response = $this->get(route("signup.get"));
+//         $response->assertStatus(200);
+//     }
     
-    public function test_request_should_pass_when_data_is_provided()
-    {   
-        $this->withoutExceptionHandling();
+//     public function test_request_should_pass_when_data_is_provided()
+//     {   
+//         $this->withoutExceptionHandling();
         
-        // ユーザー登録
-        $response = $this->from(route("welcome"))->post(route("signup.post"),[
-            "name" => "aaa",
-            "email" => "bbb@gmail.com",
-            "password" => "cccccc",
-            "password_confirmation" => "cccccc"
-        ]);
+//         // ユーザー登録
+//         $response = $this->from(route("welcome"))->post(route("signup.post"),[
+//             "name" => "aaa",
+//             "email" => "bbb@gmail.com",
+//             "password" => "cccccc",
+//             "password_confirmation" => "cccccc"
+//         ]);
         
-        // // ユーザー登録成功後、トップページにページ移動
-        $response->assertStatus(302);
-        $response->assertRedirect(route("home"));
+//         // // ユーザー登録成功後、トップページにページ移動
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("home"));
         
-        // データベースのusersテーブルに追加されていることを確認
-        $this->assertDatabaseHas("users", [
-            "name" => "aaa",
-            "email" => "bbb@gmail.com",
-        ]);
+//         // データベースのusersテーブルに追加されていることを確認
+//         $this->assertDatabaseHas("users", [
+//             "name" => "aaa",
+//             "email" => "bbb@gmail.com",
+//         ]);
         
-        $user = User::where("email", "bbb@gmail.com")->first();
-        $this->assertTrue(Hash::check("cccccc", $user->password));
-    }
+//         $user = User::where("email", "bbb@gmail.com")->first();
+//         $this->assertTrue(Hash::check("cccccc", $user->password));
+//     }
     
-    public function test_request_should_fail_when_no_name_is_provided()
-    {   
-        // ユーザー名を空白の状態でユーザー登録を試みる
-        $response = $this->from(route("signup.get"))->post(route("signup.post"),[
-            "name" => "",
-            "email" => "bbb@gmail.com",
-            "password" => "cccccc",
-            "password_confirmation" => "cccccc",
-        ]);
+//     public function test_request_should_fail_when_no_name_is_provided()
+//     {   
+//         // ユーザー名を空白の状態でユーザー登録を試みる
+//         $response = $this->from(route("signup.get"))->post(route("signup.post"),[
+//             "name" => "",
+//             "email" => "bbb@gmail.com",
+//             "password" => "cccccc",
+//             "password_confirmation" => "cccccc",
+//         ]);
         
-        // ユーザー登録に失敗し、同画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route("signup.get"));
+//         // ユーザー登録に失敗し、同画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("signup.get"));
         
-        // データベースのusersテーブルに追加されていないことを確認
-        $this->assertDatabaseMissing("users", [
-            "name" => "",
-            "email" => "bbb@gmail.com",
-        ]);
-    }
+//         // データベースのusersテーブルに追加されていないことを確認
+//         $this->assertDatabaseMissing("users", [
+//             "name" => "",
+//             "email" => "bbb@gmail.com",
+//         ]);
+//     }
     
-    public function test_request_should_fail_when_no_email_is_provided()
-    {   
-       // メールアドレスを空白の状態でユーザー登録を試みる
-        $response = $this->from(route("signup.get"))->post(route("signup.post"),[
-            "name" => "aaa",
-            "email" => "",
-            "password" => "cccccc",
-            "password_confirmation" => "cccccc"
-        ]);
+//     public function test_request_should_fail_when_no_email_is_provided()
+//     {   
+//        // メールアドレスを空白の状態でユーザー登録を試みる
+//         $response = $this->from(route("signup.get"))->post(route("signup.post"),[
+//             "name" => "aaa",
+//             "email" => "",
+//             "password" => "cccccc",
+//             "password_confirmation" => "cccccc"
+//         ]);
         
-        // ユーザー登録に失敗し、同画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route("signup.get"));
+//         // ユーザー登録に失敗し、同画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("signup.get"));
         
-        // データベースのusersテーブルに追加されていないことを確認
-        $this->assertDatabaseMissing("users", [
-            "name" => "aaa",
-            "email" => "",
-        ]);
-    }
+//         // データベースのusersテーブルに追加されていないことを確認
+//         $this->assertDatabaseMissing("users", [
+//             "name" => "aaa",
+//             "email" => "",
+//         ]);
+//     }
     
-    public function test_request_should_fail_when_no_password_is_provided()
-    {   
-        // パスワードを空白のままユーザー登録を試みる
-        $response = $this->from(route("signup.get"))->post(route("signup.post"),[
-            "name" => "aaa",
-            "email" => "bbb@gmail.com",
-            "password" => "",
-            "password_confirmation" => "",
-        ]);
+//     public function test_request_should_fail_when_no_password_is_provided()
+//     {   
+//         // パスワードを空白のままユーザー登録を試みる
+//         $response = $this->from(route("signup.get"))->post(route("signup.post"),[
+//             "name" => "aaa",
+//             "email" => "bbb@gmail.com",
+//             "password" => "",
+//             "password_confirmation" => "",
+//         ]);
         
-        // ユーザー登録に失敗し、同画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route("signup.get"));
+//         // ユーザー登録に失敗し、同画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("signup.get"));
         
-        // データベースのusersテーブルに追加されていないことを確認
-        $this->assertDatabaseMissing("users", [
-            "name" => "aaa",
-            "email" => "bbb@gmail.com",
-        ]);
-    }
+//         // データベースのusersテーブルに追加されていないことを確認
+//         $this->assertDatabaseMissing("users", [
+//             "name" => "aaa",
+//             "email" => "bbb@gmail.com",
+//         ]);
+//     }
     
-    public function test_request_should_fail_when_password_doesnot_match_password_confirmation()
-    {   
-        // パスワード記入欄の値とパスワード確認欄の値が異なるままユーザー登録を試みる
-        $response = $this->from(route("signup.get"))->post(route("signup.post"),[
-            "name" => "aaa",
-            "email" => "bbb@gmail.com",
-            "password" => "cccccc",
-            "password_confirmation" => "dddddd"
-        ]);
+//     public function test_request_should_fail_when_password_doesnot_match_password_confirmation()
+//     {   
+//         // パスワード記入欄の値とパスワード確認欄の値が異なるままユーザー登録を試みる
+//         $response = $this->from(route("signup.get"))->post(route("signup.post"),[
+//             "name" => "aaa",
+//             "email" => "bbb@gmail.com",
+//             "password" => "cccccc",
+//             "password_confirmation" => "dddddd"
+//         ]);
         
-        // ユーザー登録に失敗し、同画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route("signup.get"));
+//         // ユーザー登録に失敗し、同画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("signup.get"));
         
-        // データベースのusersテーブルに追加されていないことを確認
-        $this->assertDatabaseMissing("users", [
-            "name" => "aaa",
-            "email" => "bbb@gmail.com",
-            "password" => bcrypt("cccccc"),
-        ]);
-    }
-}
+//         // データベースのusersテーブルに追加されていないことを確認
+//         $this->assertDatabaseMissing("users", [
+//             "name" => "aaa",
+//             "email" => "bbb@gmail.com",
+//             "password" => bcrypt("cccccc"),
+//         ]);
+//     }
+// }

--- a/tests/Feature/SaveSongRequestTest.php
+++ b/tests/Feature/SaveSongRequestTest.php
@@ -1,135 +1,135 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Http\Response;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Http\Response;
+// use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 
-use App\User;
-use App\Song;
+// use App\User;
+// use App\Song;
 
-class SaveSongRequestTest extends TestCase
-{
-    /**
-     * A basic test example.
-     *
-     * @return void
-     */
+// class SaveSongRequestTest extends TestCase
+// {
+//     /**
+//      * A basic test example.
+//      *
+//      * @return void
+//      */
      
-    use RefreshDatabase;
-    use WithoutMiddleware;
+//     use RefreshDatabase;
+//     use WithoutMiddleware;
     
-    public function test_user_can_see_song_post_page()
-    {   
-        $this->withoutExceptionHandling();
+//     public function test_user_can_see_song_post_page()
+//     {   
+//         $this->withoutExceptionHandling();
         
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        //曲の投稿画面を表示する
-        $response = $this->actingAs($user)->get(route("songs.create"));
-        $response->assertStatus(200);
-    }
+//         //曲の投稿画面を表示する
+//         $response = $this->actingAs($user)->get(route("songs.create"));
+//         $response->assertStatus(200);
+//     }
     
-    public function test_request_should_pass_when_data_is_provided()
-    {
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_request_should_pass_when_data_is_provided()
+//     {
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        //曲を投稿する
-        $response = $this->actingAs($user)->post(route("songs.store"),[
-            "title" => "AAA",
-            "artist_name" => "BBB",
-            "music_age" => 1970,
-        ]);
+//         //曲を投稿する
+//         $response = $this->actingAs($user)->post(route("songs.store"),[
+//             "title" => "AAA",
+//             "artist_name" => "BBB",
+//             "music_age" => 1970,
+//         ]);
 
-        // プロフィール画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route('users.show',["id" => $user->id]));
+//         // プロフィール画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route('users.show',["id" => $user->id]));
         
-        // データベースに曲が保存されていることを確認
-        $this->assertDatabaseHas('songs', [
-            "title" => "AAA",
-            "artist_name" => "BBB",
-            "music_age" => 1970,
-        ]);
-    }
+//         // データベースに曲が保存されていることを確認
+//         $this->assertDatabaseHas('songs', [
+//             "title" => "AAA",
+//             "artist_name" => "BBB",
+//             "music_age" => 1970,
+//         ]);
+//     }
     
-    public function test_request_should_fail_when_no_title_is_provided()
-    {   
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_request_should_fail_when_no_title_is_provided()
+//     {   
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        //曲名を空白にして曲の投稿を試みる
-        $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
-            "title" => "",
-            "artist_name" => "BBB",
-            "music_age" => 1970,
-        ]);
+//         //曲名を空白にして曲の投稿を試みる
+//         $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
+//             "title" => "",
+//             "artist_name" => "BBB",
+//             "music_age" => 1970,
+//         ]);
         
-        // 同画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route("songs.create"));
+//         // 同画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("songs.create"));
         
-        // データベースに曲が存在しないことを確認
-        $this->assertDatabaseMissing('songs', [
-            "title" => "",
-            "artist_name" => "BBB",
-            "music_age" => 1970,
-        ]);
+//         // データベースに曲が存在しないことを確認
+//         $this->assertDatabaseMissing('songs', [
+//             "title" => "",
+//             "artist_name" => "BBB",
+//             "music_age" => 1970,
+//         ]);
         
-    }
+//     }
     
-    public function test_request_should_fail_when_no_artist_name_is_provided()
-    {   
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_request_should_fail_when_no_artist_name_is_provided()
+//     {   
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        //アーティスト名を空白にして曲投稿を試みる
-        $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
-            "title" => "AAA",
-            "artist_name" => "",
-            "music_age" => 1970,
-        ]);
+//         //アーティスト名を空白にして曲投稿を試みる
+//         $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
+//             "title" => "AAA",
+//             "artist_name" => "",
+//             "music_age" => 1970,
+//         ]);
         
-        // 同画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route("songs.create"));
+//         // 同画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("songs.create"));
         
-        // データベースに曲が存在しないことを確認
-        $this->assertDatabaseMissing('songs', [
-            "title" => "AAA",
-            "artist_name" => "",
-            "music_age" => 1970,
-        ]);
+//         // データベースに曲が存在しないことを確認
+//         $this->assertDatabaseMissing('songs', [
+//             "title" => "AAA",
+//             "artist_name" => "",
+//             "music_age" => 1970,
+//         ]);
         
-    }
+//     }
     
-    public function test_request_should_fail_when_no_music_age_is_provided()
-    {   
-         // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_request_should_fail_when_no_music_age_is_provided()
+//     {   
+//          // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
-            "title" => "AAA",
-            "artist_name" => "BBB",
-            "music_age" => "",
-        ]);
+//         $response = $this->actingAs($user)->from(route("songs.create"))->post(route("songs.store"),[
+//             "title" => "AAA",
+//             "artist_name" => "BBB",
+//             "music_age" => "",
+//         ]);
         
-        // 同画面に戻る
-        $response->assertStatus(302);
-        $response->assertRedirect(route("songs.create"));
+//         // 同画面に戻る
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("songs.create"));
         
-        // データベースに曲が存在しないことを確認
-        $this->assertDatabaseMissing('songs', [
-            "title" => "AAA",
-            "artist_name" => "BBB",
-            "music_age" => "",
-        ]);
-    }
+//         // データベースに曲が存在しないことを確認
+//         $this->assertDatabaseMissing('songs', [
+//             "title" => "AAA",
+//             "artist_name" => "BBB",
+//             "music_age" => "",
+//         ]);
+//     }
     
-}
+// }

--- a/tests/Feature/UploadSongImageRequestTest.php
+++ b/tests/Feature/UploadSongImageRequestTest.php
@@ -1,80 +1,80 @@
 <?php
-namespace Tests\Feature;
-use Tests\TestCase;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
-use App\User;
-use App\Song;
+// namespace Tests\Feature;
+// use Tests\TestCase;
+// use Illuminate\Http\UploadedFile;
+// use Illuminate\Support\Facades\Storage;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Foundation\Testing\WithoutMiddleware;
+// use App\User;
+// use App\Song;
 
-class UploadSongImageRequestTest extends TestCase
-{
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
+// class UploadSongImageRequestTest extends TestCase
+// {
+//     /**
+//      * A basic feature test example.
+//      *
+//      * @return void
+//      */
      
-    use RefreshDatabase;
-    use WithoutMiddleware;
+//     use RefreshDatabase;
+//     use WithoutMiddleware;
     
-    public function test_user_can_see_song_image_upload_form()
-    {
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_user_can_see_song_image_upload_form()
+//     {
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        // 曲を1つ作成
-        $song = factory(Song::class)->create();
+//         // 曲を1つ作成
+//         $song = factory(Song::class)->create();
         
-        // 曲画像アップロード画面に移動する
-        $response = $this->actingAs($user)->get(route("songs.imagesUploadForm", ["id" => $song->id]));
-        $response->assertStatus(200);
-    }
+//         // 曲画像アップロード画面に移動する
+//         $response = $this->actingAs($user)->get(route("songs.imagesUploadForm", ["id" => $song->id]));
+//         $response->assertStatus(200);
+//     }
     
-   // public function test_upload_song_image_request_should_pass_when_file_is_provided()
-   // {   
-        // ユーザーを1人作成
-   //     $user = factory(User::class)->create();
+//    // public function test_upload_song_image_request_should_pass_when_file_is_provided()
+//    // {   
+//         // ユーザーを1人作成
+//    //     $user = factory(User::class)->create();
         
-        // 上で作ったユーザーで曲を1つ投稿
-   //     $song = factory(Song::class)->create([
-   //         "user_id" => $user->id,
-   //     ]);
+//         // 上で作ったユーザーで曲を1つ投稿
+//    //     $song = factory(Song::class)->create([
+//    //         "user_id" => $user->id,
+//    //     ]);
         
-   //     $uploadedFile = UploadedFile::fake()->image("jacket.jpg");
+//    //     $uploadedFile = UploadedFile::fake()->image("jacket.jpg");
         
-        //画像をアップロードする
-   //     $response = $this->actingAs($user)->post(route("songs.imagesUpload", ["id" => $song->id]),[
-   //         "file" => $uploadedFile,
-   //     ]);
+//         //画像をアップロードする
+//    //     $response = $this->actingAs($user)->post(route("songs.imagesUpload", ["id" => $song->id]),[
+//    //         "file" => $uploadedFile,
+//    //     ]);
         
-        // 画像アップロード後に曲詳細画面に戻る
-   //     $response->assertRedirect(route("songs.show", ["id" => $song->id]));
+//         // 画像アップロード後に曲詳細画面に戻る
+//    //     $response->assertRedirect(route("songs.show", ["id" => $song->id]));
         
-        // S3にアップロードされたかはS3のバケットを確認しました。
-   // }
+//         // S3にアップロードされたかはS3のバケットを確認しました。
+//    // }
     
-   // public function test_upoad_song_image_request_should_fail_when_no_file_is_provided()
-   // {   
-        // ユーザーを1人作成
-   //     $user = factory(User::class)->create();
+//    // public function test_upoad_song_image_request_should_fail_when_no_file_is_provided()
+//    // {   
+//         // ユーザーを1人作成
+//    //     $user = factory(User::class)->create();
         
-        // 上で作ったユーザーで曲を1つ投稿
-   //     $song = factory(Song::class)->create([
-   //         "user_id" => $user->id,
-   //     ]);
+//         // 上で作ったユーザーで曲を1つ投稿
+//    //     $song = factory(Song::class)->create([
+//    //         "user_id" => $user->id,
+//    //     ]);
         
-        //ファイルを選択せずにアップロードを試みる
-   //     $response = $this->actingAs($user)->from(route("songs.imagesUploadForm", ["id" => $song->id]))->post(route("songs.imagesUpload", ["id" => $song->id]),[
-   //         "file" => "",
-   //     ]);
+//         //ファイルを選択せずにアップロードを試みる
+//    //     $response = $this->actingAs($user)->from(route("songs.imagesUploadForm", ["id" => $song->id]))->post(route("songs.imagesUpload", ["id" => $song->id]),[
+//    //         "file" => "",
+//    //     ]);
         
-        // アップロードに失敗し、曲画像のアップロード画面が表示される
-   //     $response->assertStatus(302);
-   //     $response->assertRedirect(route("songs.imagesUploadForm", ["id" => $song->id]));
+//         // アップロードに失敗し、曲画像のアップロード画面が表示される
+//    //     $response->assertStatus(302);
+//    //     $response->assertRedirect(route("songs.imagesUploadForm", ["id" => $song->id]));
         
-        // S3にアップロードされていないことをはS3のバケットにて確認しました。
-   // }
-}
+//         // S3にアップロードされていないことをはS3のバケットにて確認しました。
+//    // }
+// }

--- a/tests/Feature/UploadUserImageRequestTest.php
+++ b/tests/Feature/UploadUserImageRequestTest.php
@@ -1,67 +1,67 @@
 <?php
-namespace Tests\Feature;
-use Tests\TestCase;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
-use App\User;
-use App\Song;
+// namespace Tests\Feature;
+// use Tests\TestCase;
+// use Illuminate\Http\UploadedFile;
+// use Illuminate\Support\Facades\Storage;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Foundation\Testing\WithoutMiddleware;
+// use App\User;
+// use App\Song;
 
-class UploadUserImageRequestTest extends TestCase
-{
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
+// class UploadUserImageRequestTest extends TestCase
+// {
+//     /**
+//      * A basic feature test example.
+//      *
+//      * @return void
+//      */
      
-    use RefreshDatabase;
-    use WithoutMiddleware;
+//     use RefreshDatabase;
+//     use WithoutMiddleware;
     
-    public function test_user_can_see_user_image_upload_form()
-    {
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_user_can_see_user_image_upload_form()
+//     {
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        // ユーザー画像のアップロード画面に移動する
-        $response = $this->actingAs($user)->get(route("users.imagesUploadForm", ["id" => $user->id]));
-        $response->assertStatus(200);
-    }
+//         // ユーザー画像のアップロード画面に移動する
+//         $response = $this->actingAs($user)->get(route("users.imagesUploadForm", ["id" => $user->id]));
+//         $response->assertStatus(200);
+//     }
     
-    //public function test_upload_user_image_request_should_pass_when_file_is_provided()
-    //{   
-        // ユーザーを1人作成
-    //    $user = factory(User::class)->create();
+//     //public function test_upload_user_image_request_should_pass_when_file_is_provided()
+//     //{   
+//         // ユーザーを1人作成
+//     //    $user = factory(User::class)->create();
         
-    //    $uploadedFile = UploadedFile::fake()->image("avatar.jpg");
+//     //    $uploadedFile = UploadedFile::fake()->image("avatar.jpg");
         
-        //画像をアップロードする
-    //    $response = $this->actingAs($user)->post(route("users.imagesUpload", ["id" => $user->id]),[
-    //        "file" => $uploadedFile,
-    //    ]);
+//         //画像をアップロードする
+//     //    $response = $this->actingAs($user)->post(route("users.imagesUpload", ["id" => $user->id]),[
+//     //        "file" => $uploadedFile,
+//     //    ]);
         
-        // ユーザー画像をアップロード後にマイページに戻る
-    //    $response->assertRedirect(route("users.show", ["id" => $user->id]));
+//         // ユーザー画像をアップロード後にマイページに戻る
+//     //    $response->assertRedirect(route("users.show", ["id" => $user->id]));
         
-        // S3にアップロードされたかはS3のバケットを確認しました。
-    //}
+//         // S3にアップロードされたかはS3のバケットを確認しました。
+//     //}
     
-    //public function test_upoad_user_image_request_should_fail_when_no_file_is_provided()
-    //{   
-        // ユーザーを1人作成
-    //    $user = factory(User::class)->create();
+//     //public function test_upoad_user_image_request_should_fail_when_no_file_is_provided()
+//     //{   
+//         // ユーザーを1人作成
+//     //    $user = factory(User::class)->create();
         
-        //ファイルを選択せずに画像のアップロードを試みる
-    //    $response = $this->actingAs($user)->from(route("users.imagesUploadForm", ["id" => $user->id]))->post(route("users.imagesUpload", ["id" => $user->id]),[
-    //        "file" => "",
-    //    ]);
+//         //ファイルを選択せずに画像のアップロードを試みる
+//     //    $response = $this->actingAs($user)->from(route("users.imagesUploadForm", ["id" => $user->id]))->post(route("users.imagesUpload", ["id" => $user->id]),[
+//     //        "file" => "",
+//     //    ]);
         
-        // アップロードに失敗し、ユーザー画像のアップロード画面が表示される
-    //    $response->assertStatus(302);
-    //    $response->assertRedirect(route("users.imagesUploadForm", ["id" => $user->id]));
+//         // アップロードに失敗し、ユーザー画像のアップロード画面が表示される
+//     //    $response->assertStatus(302);
+//     //    $response->assertRedirect(route("users.imagesUploadForm", ["id" => $user->id]));
         
-        // S3にアップロードされていないことをS3のバケットにて確認しました。
-    //}
-}
+//         // S3にアップロードされていないことをS3のバケットにて確認しました。
+//     //}
+// }

--- a/tests/Feature/UserFollowTest.php
+++ b/tests/Feature/UserFollowTest.php
@@ -1,86 +1,86 @@
 <?php
 
-namespace Tests\Feature;
+// namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithoutMiddleware;
+// use Tests\TestCase;
+// use Illuminate\Foundation\Testing\WithFaker;
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+// use Illuminate\Foundation\Testing\WithoutMiddleware;
 
-use App\User;
-use Auth;
+// use App\User;
+// use Auth;
 
-class UserFollowTest extends TestCase
-{
-    /**
-     * A basic test example.
-     *
-     * @return void
-     */
+// class UserFollowTest extends TestCase
+// {
+//     /**
+//      * A basic test example.
+//      *
+//      * @return void
+//      */
      
-    use RefreshDatabase;
-    use WithoutMiddleware;
+//     use RefreshDatabase;
+//     use WithoutMiddleware;
      
-    public function test_user_can_follow()
-    {
-        // ユーザーを2人作成
-        $user1 = factory(User::class)->create();
-        $user2 = factory(User::class)->create();
+//     public function test_user_can_follow()
+//     {
+//         // ユーザーを2人作成
+//         $user1 = factory(User::class)->create();
+//         $user2 = factory(User::class)->create();
            
-        // ユーザー1がユーザー2をフォローする
-        $response = $this->actingAs($user1)->from(route("users.show", ["id" => $user2->id]))->post(route("user.follow", ["id" => $user2->id]));
+//         // ユーザー1がユーザー2をフォローする
+//         $response = $this->actingAs($user1)->from(route("users.show", ["id" => $user2->id]))->post(route("user.follow", ["id" => $user2->id]));
            
-        // 同じ画面にリダイレクト
-        $response->assertStatus(302);
-        $response->assertRedirect(route("users.show", ["id" => $user2->id]));
+//         // 同じ画面にリダイレクト
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("users.show", ["id" => $user2->id]));
         
-        // データベースにフォロー・フォロワーの関係が保存されていることを確認
-        $this->assertDatabaseHas('user_follow', [
-            "user_id" => $user1->id,
-            "follow_id" => $user2->id,
-        ]);
-    }
+//         // データベースにフォロー・フォロワーの関係が保存されていることを確認
+//         $this->assertDatabaseHas('user_follow', [
+//             "user_id" => $user1->id,
+//             "follow_id" => $user2->id,
+//         ]);
+//     }
     
-    public function test_user_can_unfollow()
-    {
-        // ユーザーを2人作成
-        $user1 = factory(User::class)->create();
-        $user2 = factory(User::class)->create();
+//     public function test_user_can_unfollow()
+//     {
+//         // ユーザーを2人作成
+//         $user1 = factory(User::class)->create();
+//         $user2 = factory(User::class)->create();
            
-        // ユーザー1がユーザー2をフォローする
-        $response = $this->actingAs($user1)->from(route("users.show", ["id" => $user2->id]))->post(route("user.follow", ["id" => $user2->id]));
+//         // ユーザー1がユーザー2をフォローする
+//         $response = $this->actingAs($user1)->from(route("users.show", ["id" => $user2->id]))->post(route("user.follow", ["id" => $user2->id]));
         
-        // ユーザー1がユーザー2のフォローを外す
-        $response = $this->actingAs($user1)->from(route("users.show", ["id" => $user2->id]))->delete(route("user.unfollow", ["id" => $user2->id]));
+//         // ユーザー1がユーザー2のフォローを外す
+//         $response = $this->actingAs($user1)->from(route("users.show", ["id" => $user2->id]))->delete(route("user.unfollow", ["id" => $user2->id]));
            
-        // 同じ画面にリダイレクト
-        $response->assertStatus(302);
-        $response->assertRedirect(route("users.show", ["id" => $user2->id]));
+//         // 同じ画面にリダイレクト
+//         $response->assertStatus(302);
+//         $response->assertRedirect(route("users.show", ["id" => $user2->id]));
         
-        // データベースからフォロー・フォロワーの関係のデータがなくなっていることを確認
-        $this->assertDatabaseMissing('user_follow', [
-            "user_id" => $user1->id,
-            "follow_id" => $user2->id,
-        ]);
-    }
+//         // データベースからフォロー・フォロワーの関係のデータがなくなっていることを確認
+//         $this->assertDatabaseMissing('user_follow', [
+//             "user_id" => $user1->id,
+//             "follow_id" => $user2->id,
+//         ]);
+//     }
     
-    public function test_user_can_see_followings()
-    {
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_user_can_see_followings()
+//     {
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        // ユーザーがフォローしているユーザー一覧を見る
-        $response = $this->actingAs($user)->get(route("users.followings", ["id" => $user->id]));  
-        $response->assertStatus(200);
-    }
+//         // ユーザーがフォローしているユーザー一覧を見る
+//         $response = $this->actingAs($user)->get(route("users.followings", ["id" => $user->id]));  
+//         $response->assertStatus(200);
+//     }
     
-    public function test_user_can_see_followers()
-    {
-        // ユーザーを1人作成
-        $user = factory(User::class)->create();
+//     public function test_user_can_see_followers()
+//     {
+//         // ユーザーを1人作成
+//         $user = factory(User::class)->create();
         
-        // ユーザーが自分をフォローしているユーザー一覧を見る
-        $response = $this->actingAs($user)->get(route("users.followers", ["id" => $user->id]));  
-        $response->assertStatus(200);
-    }
-}
+//         // ユーザーが自分をフォローしているユーザー一覧を見る
+//         $response = $this->actingAs($user)->get(route("users.followers", ["id" => $user->id]));  
+//         $response->assertStatus(200);
+//     }
+// }


### PR DESCRIPTION
SPA化に伴い、LaravelはAPIを返すのが目的なので、不要なルーティングは削除